### PR TITLE
Minor version published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0-beta.0] - 2019-10-04
+
+### Added
+
+- NA
+
+### Changed
+
+- NA
+
+### Removed
+
+- [`ONCEHUB-19619`](https://scheduleonce.atlassian.net/browse/ONCEHUB-19619) Old-date picker removed from the Once-ui Library.
+
+### Fixed
+
+- NA
+
 ## [1.11.17-0] - 2019-09-27
 
 ### Added

--- a/projects/ui/package-lock.json
+++ b/projects/ui/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@once/ui",
-  "version": "1.11.17-0",
+  "version": "1.12.0-beta.0",
   "lockfileVersion": 1
 }

--- a/projects/ui/package.json
+++ b/projects/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@once/ui",
-  "version": "1.11.17-0",
+  "version": "1.12.0-beta.0",
   "peerDependencies": {
     "@angular/common": "^6.0.0-rc.0 || ^6.0.0",
     "@angular/core": "^6.0.0-rc.0 || ^6.0.0",


### PR DESCRIPTION
- [`ONCEHUB-19619`](https://scheduleonce.atlassian.net/browse/ONCEHUB-19619) Old-date picker removed from the Once-ui Library.
