### PR TITLE
On app2- the cursor pointing to the top of the bot page after remove hovering from bot response tooltip(ONCEHUB-26932)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 /coverage
 /libpeerconnection.log
 npm-debug.log
+.npmrc
 yarn-error.log
 testem.log
 /typings

--- a/projects/ui/src/lib/oui/panel/panel-trigger.ts
+++ b/projects/ui/src/lib/oui/panel/panel-trigger.ts
@@ -8,8 +8,7 @@ import {
   EventEmitter,
   ElementRef,
   ViewContainerRef,
-  Inject,
-  Optional
+  Inject
 } from '@angular/core';
 import {
   ScrollStrategy,
@@ -30,7 +29,6 @@ import { merge } from 'rxjs';
 import { debounceTime, filter } from 'rxjs/operators';
 import { SPACE } from '@angular/cdk/keycodes';
 import { FocusTrap, FocusTrapFactory } from '@angular/cdk/a11y';
-import { DOCUMENT } from '@angular/common';
 
 /** Injection token that determines the scroll handling while the panel-overlay is open. */
 export const OUI_PANEL_SCROLL_STRATEGY = new InjectionToken<
@@ -84,7 +82,7 @@ export class OuiPanelTrigger implements AfterContentInit, OnDestroy {
   private _focusTrap: FocusTrap;
 
   /** Element that was focused before the panel was opened. Save this to restore upon close. */
-  private _elementFocusedBeforeDialogWasOpened: HTMLElement = null;
+  private _currentFocusElement: HTMLElement = null;
 
   /** References the panel instance that the trigger is associated with. */
   @Input('ouiPanelTriggerFor')
@@ -124,7 +122,6 @@ export class OuiPanelTrigger implements AfterContentInit, OnDestroy {
     private _element: ElementRef<HTMLElement>,
     private _viewContainerRef: ViewContainerRef,
     private _focusTrapFactory: FocusTrapFactory,
-    @Optional() @Inject(DOCUMENT) private _document: any,
     @Inject(OUI_PANEL_SCROLL_STRATEGY) scrollStrategy: any
   ) {
     this._scrollStrategy = scrollStrategy;
@@ -149,6 +146,8 @@ export class OuiPanelTrigger implements AfterContentInit, OnDestroy {
     if (keyCode === SPACE) {
       this.openPanel();
       event.preventDefault();
+      // // on keypad tab it will focus on the element itself
+      this._currentFocusElement = event.target as HTMLElement;
     }
   }
 
@@ -309,8 +308,7 @@ export class OuiPanelTrigger implements AfterContentInit, OnDestroy {
 
   /** Restores focus to the element that was focused before the panel opened. */
   public _restoreFocus() {
-    const toFocus = this._elementFocusedBeforeDialogWasOpened;
-
+    const toFocus = this._currentFocusElement;
     // We need the extra check, because IE can set the `activeElement` to null in some cases.
     if (toFocus && typeof toFocus.focus === 'function') {
       toFocus.focus();
@@ -318,22 +316,6 @@ export class OuiPanelTrigger implements AfterContentInit, OnDestroy {
 
     if (this._focusTrap) {
       this._focusTrap = null;
-    }
-  }
-
-  /** Saves a reference to the element that was focused before the panel was opened. */
-  private _savePreviouslyFocusedElement() {
-    if (this._document) {
-      this._elementFocusedBeforeDialogWasOpened = this._document
-        .activeElement as HTMLElement;
-
-      // Note that there is no focus method when rendering on the server.
-      if (this._element.nativeElement.focus) {
-        // Move focus onto the panel immediately in order to prevent the user from accidentally
-        // opening multiple panels at the same time. Needs to be async, because the element
-        // may not be focusable immediately.
-        Promise.resolve().then(() => this._element.nativeElement.focus());
-      }
     }
   }
 
@@ -348,11 +330,13 @@ export class OuiPanelTrigger implements AfterContentInit, OnDestroy {
         this._viewContainerRef
       );
     }
-    this._savePreviouslyFocusedElement();
     return this._portal;
   }
 
   public _handleMouseEnter(event: MouseEvent): void {
+    // on hover it will focus on the element itself
+    const focusElement = event.target as HTMLElement;
+    this._currentFocusElement = focusElement.querySelector('oui-icon');
     this._mouseEnter.next(event);
     this.openPanel();
     event.stopImmediatePropagation();


### PR DESCRIPTION
## For code author

### What does this PR do?
This PR is for the cursor pointing scrolling to the top of the bot page after remove hovering from the bot response panel icon.
After hovering out from the panel icon, the focus will be scrolled to the last focused position.

So this PR resolves this issue as on hovering, we are moving the focus from the last focused element to the hovering element.

### Why do we want to do that?
For fixing the scrolled to the last focused element, when we hover out the panel icon.

### What are the high-level changes?

### What other information should the reviewer be aware of when looking at this code?

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
