### PR TITLE
technocrats/OuiTooltip

### DIFF
--- a/projects/ui/src/lib/oui/tooltip/tooltip.ts
+++ b/projects/ui/src/lib/oui/tooltip/tooltip.ts
@@ -151,7 +151,7 @@ export class TooltipComponent {
   constructor(
     private _changeDetectorRef: ChangeDetectorRef,
     private _breakpointObserver: BreakpointObserver
-  ) { }
+  ) {}
 
   /**
    * Shows the tooltip with an animation originating from the provided origin

--- a/projects/ui/src/lib/oui/tooltip/tooltip.ts
+++ b/projects/ui/src/lib/oui/tooltip/tooltip.ts
@@ -38,6 +38,7 @@ import {
 } from '@angular/core';
 import { Subject, Observable } from 'rxjs';
 import { ouiTooltipAnimations } from './tooltip-animations';
+import { CanDisable } from '../core';
 
 export type TooltipPosition = 'left' | 'right' | 'above' | 'below';
 
@@ -150,7 +151,7 @@ export class TooltipComponent {
   constructor(
     private _changeDetectorRef: ChangeDetectorRef,
     private _breakpointObserver: BreakpointObserver
-  ) {}
+  ) { }
 
   /**
    * Shows the tooltip with an animation originating from the provided origin
@@ -251,11 +252,11 @@ export class TooltipComponent {
     '(longpress)': 'show()',
     '(keydown)': '_handleKeydown($event)',
     '(touchend)': '_handleTouchend()',
-    '[attr.tabindex]': '_disabled ? -1 : (tabIndex || 0)',
+    '[attr.tabindex]': 'disabled ? -1 : 0',
     '[attr.aria-hidden]': 'false'
   }
 })
-export class OuiTooltip implements OnDestroy {
+export class OuiTooltip implements OnDestroy, CanDisable {
   _overlayRef: OverlayRef | null;
   _tooltipInstance: TooltipComponent | null;
 


### PR DESCRIPTION
## For code author

### What does this PR do?
Added CanDisable in OuiTooltip and remove the tabIndex.
### Why do we want to do that?
Because tabIndex property is not defined and _disabled was private but was being used in Host that was causing builds to fail and we need to fix it.
### What are the high level changes?

### What other information should the reviewer be aware of when looking at this code?
ouiTooltip Class is now overriding disabled property of CanDisable interface.
### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
