### PR TITLE
once-ui dialog focus tab order issues

### DIFF
--- a/projects/ui/src/lib/oui/dialog/README.md
+++ b/projects/ui/src/lib/oui/dialog/README.md
@@ -273,6 +273,8 @@ By default, the first tabbable element within the dialog will receive focus upon
 
 Tabbing through the elements of the dialog will keep focus inside of the dialog element, wrapping back to the first tabbable element when reaching the end of the tab sequence.
 
+Regions can be declared explicitly with an initial focus element by using the `cdkFocusRegionStart`, `cdkFocusRegionEnd` DOM attributes. `cdkFocusRegionStart` and `cdkFocusRegionEnd` define the region within which focus will be trapped. When using the tab key, focus will move through this region and wrap around on either end.
+
 #### Keyboard interaction
 
 By default pressing the escape key will close the dialog. While this behavior can be turned off via the `disableClose` option, users should generally avoid doing so as it breaks the expected interaction pattern for screen-reader users.

--- a/projects/ui/src/lib/oui/dialog/README.md
+++ b/projects/ui/src/lib/oui/dialog/README.md
@@ -275,6 +275,21 @@ Tabbing through the elements of the dialog will keep focus inside of the dialog 
 
 Regions can be declared explicitly with an initial focus element by using the `cdkFocusRegionStart`, `cdkFocusRegionEnd` DOM attributes. `cdkFocusRegionStart` and `cdkFocusRegionEnd` define the region within which focus will be trapped. When using the tab key, focus will move through this region and wrap around on either end.
 
+For example:
+
+```html
+<div oui-dialog-footer>
+  <div oui-dialog-footer-action-left>
+    <button oui-ghost-button cdkFocusRegionStart>Left</button>
+    <button oui-link-button>Left</button>
+  </div>
+  <div oui-dialog-footer-action-right>
+    <button oui-ghost-button cdkFocusInitial>Open</button>
+    <button oui-button ouiDialogClose cdkFocusRegionEnd>Close</button>
+  </div>
+</div>
+```
+
 #### Keyboard interaction
 
 By default pressing the escape key will close the dialog. While this behavior can be turned off via the `disableClose` option, users should generally avoid doing so as it breaks the expected interaction pattern for screen-reader users.

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -489,12 +489,14 @@
     </div>
     <div oui-dialog-footer>
       <div oui-dialog-footer-action-left>
-        <button oui-link-button>Left</button>
+        <button oui-link-button cdkFocusRegionStart>Left</button>
         <button oui-link-button>Left</button>
       </div>
       <div oui-dialog-footer-action-right>
-        <button oui-ghost-button (click)="openDialog()">Open</button>
-        <button oui-button ouiDialogClose>Close</button>
+        <button oui-ghost-button (click)="openDialog()" cdkFocusInitial>
+          Open
+        </button>
+        <button oui-button ouiDialogClose cdkFocusRegionEnd>Close</button>
       </div>
     </div>
   </ng-template>


### PR DESCRIPTION
https://scheduleonce.atlassian.net/browse/ONCEHUB-26348
## For code author

### What does this PR do?
Adding the support for `cdkFocusInitial` which specifies the element that will receive focus upon initialization.
Added the support for Regions by using the `cdkFocusRegionStart`, `cdkFocusRegionEnd`.
### Why do we want to do that?
To improve accessibility.
### What are the high level changes?

### What other information should the reviewer be aware of when looking at this code?

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
