### PR TITLE
Adding OuiIconTestingModule for removing warning of missing icon

### DIFF
--- a/projects/ui/src/lib/oui/icon/README.md
+++ b/projects/ui/src/lib/oui/icon/README.md
@@ -41,6 +41,23 @@ export class AppComponent {
 }
 ```
 
+**OuiIconTestingModule**
+
+`import { OuiIconTestingModule } from '@oncehub/ui';`
+
+Use this module to install the null icon registry.
+
+```angular2html
+import { OuiIconTestingModule } from '@oncehub/ui';
+describe('App', () => {
+  configureTestSuite(() => {
+    TestBed.configureTestingModule({
+      imports: [OuiIconTestingModule],
+    });
+  });
+})
+```
+
 ## Services
 
 ### `OuiIconRegistry`

--- a/projects/ui/src/lib/oui/icon/public-api.ts
+++ b/projects/ui/src/lib/oui/icon/public-api.ts
@@ -1,3 +1,4 @@
 export * from './icon.module';
 export * from './icon';
 export * from './icon-registery';
+export * from './testing/fake-icon-registry';

--- a/projects/ui/src/lib/oui/icon/testing/fake-icon-registry.ts
+++ b/projects/ui/src/lib/oui/icon/testing/fake-icon-registry.ts
@@ -1,0 +1,57 @@
+import { Injectable, NgModule, OnDestroy } from '@angular/core';
+import { OuiIconRegistry } from '../icon-registery';
+import { Observable, of as observableOf } from 'rxjs';
+
+// tslint:disable:no-any Impossible to tell param types.
+type PublicApi<T> = {
+  [K in keyof T]: T[K] extends (...x: any[]) => T
+    ? (...x: any[]) => PublicApi<T>
+    : T[K]
+};
+// tslint:enable:no-any
+
+/**
+ * A null icon registry that must be imported to allow disabling of custom icons
+ */
+@Injectable()
+export class FakeOuiIconRegistry
+  implements PublicApi<OuiIconRegistry>, OnDestroy {
+  addSvgIcon(): this {
+    return this;
+  }
+
+  addSvgIconLiteral(): this {
+    return this;
+  }
+
+  addSvgIconSet(): this {
+    return this;
+  }
+
+  getNamedSvgIcon(): Observable<SVGElement> {
+    return observableOf(this._generateEmptySvg());
+  }
+
+  ngOnDestroy() {}
+
+  private _generateEmptySvg(): SVGElement {
+    const emptySvg = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'svg'
+    );
+    emptySvg.classList.add('fake-testing-svg');
+    // Emulate real icon characteristics from `OuiIconRegistry` so size remains consistent in tests.
+    emptySvg.setAttribute('fit', '');
+    emptySvg.setAttribute('height', '100%');
+    emptySvg.setAttribute('width', '100%');
+    emptySvg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+    emptySvg.setAttribute('focusable', 'false');
+    return emptySvg;
+  }
+}
+
+/** Use this module to install the null icon registry. */
+@NgModule({
+  providers: [{ provide: OuiIconRegistry, useClass: FakeOuiIconRegistry }]
+})
+export class OuiIconTestingModule {}

--- a/projects/ui/src/lib/oui/panel/panel.spec.ts
+++ b/projects/ui/src/lib/oui/panel/panel.spec.ts
@@ -44,7 +44,7 @@ class SimplePanel {
   @ViewChild(OuiPanel, { static: false }) panel: OuiPanel;
 }
 
-fdescribe('[always] OuiPanel', () => {
+describe('OuiPanel', () => {
   let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   // @ts-ignore

--- a/projects/ui/src/lib/oui/panel/panel.spec.ts
+++ b/projects/ui/src/lib/oui/panel/panel.spec.ts
@@ -18,6 +18,7 @@ import {
 import { OuiPanelModule } from './panel-module';
 import { OuiPanelTrigger } from './panel-trigger';
 import { OuiPanel } from './panel';
+import { OuiIconTestingModule } from '../icon/public-api';
 
 // tslint:disable-next-line:component-selector
 @Component({
@@ -43,7 +44,7 @@ class SimplePanel {
   @ViewChild(OuiPanel, { static: false }) panel: OuiPanel;
 }
 
-describe('OuiPanel', () => {
+fdescribe('[always] OuiPanel', () => {
   let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   // @ts-ignore
@@ -55,7 +56,7 @@ describe('OuiPanel', () => {
     declarations: any[] = []
   ): ComponentFixture<T> {
     TestBed.configureTestingModule({
-      imports: [OuiPanelModule],
+      imports: [OuiPanelModule, OuiIconTestingModule],
       declarations: [component, ...declarations],
       providers
     }).compileComponents();


### PR DESCRIPTION
## For code author

### What does this PR do?
Added a new OuiIconTestingModule to install the null icon registry.
### Why do we want to do that?
For removing warning of missing icon we are adding this OuiIconTestingModule in spec files.
### What are the high level changes?

### What other information should the reviewer be aware of when looking at this code?

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
