### PR TITLE
Set env variable CHROME_BIN

### DIFF
--- a/ui/karma.conf.js
+++ b/ui/karma.conf.js
@@ -1,6 +1,6 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
-
+process.env.CHROME_BIN = require('puppeteer').executablePath();
 module.exports = function(config) {
   config.set({
     basePath: '',


### PR DESCRIPTION
To solve error: " No binary for ChromeHeadless browser on your platform", added following

Set env variable CHROME_BIN

Added line in karma.conf.js

```
process.env.CHROME_BIN = require('puppeteer').executablePath();
```
