### PR TITLE
changed autofocus to false to remove focus from close icon in dialog

### DIFF
--- a/ui/src/components/dialog/dialog-config.ts
+++ b/ui/src/components/dialog/dialog-config.ts
@@ -81,7 +81,7 @@ export class OuiDialogConfig<D = any> {
   ariaLabel?: string | null = null;
 
   /** Whether the dialog should focus the first focusable element on open. */
-  autoFocus? = true;
+  autoFocus? = false;
 
   /**
    * Whether the dialog should restore focus to the

--- a/ui/src/components/dialog/dialog.scss
+++ b/ui/src/components/dialog/dialog.scss
@@ -114,11 +114,12 @@ $header-icon-height: 24px;
     }
   }
   &[class^='cdk'],
-  &[class$='focused'] {
+  &[class$='focused'],
+  &:hover {
     background: $icon-focus-background;
     border-radius: 2px;
     transition: $icon-focus-transition;
-  }
+  }  
 }
 .oui-dialog-header-article {
   width: $header-icon-width;

--- a/ui/src/components/dialog/dialog.scss
+++ b/ui/src/components/dialog/dialog.scss
@@ -119,7 +119,7 @@ $header-icon-height: 24px;
     background: $icon-focus-background;
     border-radius: 2px;
     transition: $icon-focus-transition;
-  }  
+  }
 }
 .oui-dialog-header-article {
   width: $header-icon-width;


### PR DESCRIPTION
## For code author
changed autofocus to false so that the close icon doesn't get highlighted when the dialog component opens up.

### What does this PR do?

### Why do we want to do that?
We don't want anything highlighted until we manually hover over it

### What are the high level changes?

### What other information should the reviewer be aware of when looking at this code?

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] New and existing unit tests pass locally with my changes
