### PR TITLE
fix close dialog button visible issue on oui-panel

### DIFF
--- a/ui/src/components/panel/panel-trigger.ts
+++ b/ui/src/components/panel/panel-trigger.ts
@@ -141,6 +141,7 @@ export class OuiPanelTrigger implements OnDestroy {
     const keyCode = event.keyCode;
     if (keyCode === SPACE) {
       this.openPanel();
+      this._trapFocus();
       event.preventDefault();
       // On tab it will focus on the element itself
       this._currentFocusElement = event.target as HTMLElement;
@@ -164,7 +165,6 @@ export class OuiPanelTrigger implements OnDestroy {
     this._closeSubscription = this._panelClosingActions().subscribe(() => {
       this.closePanel('mouserHover');
     });
-    this._trapFocus();
     this._setIsPanelOpen(true);
   }
 

--- a/ui/src/components/panel/panel.scss
+++ b/ui/src/components/panel/panel.scss
@@ -104,8 +104,10 @@ oui-panel-icon {
   line-height: 1;
   padding-bottom: 2px;
   cursor: default;
+  pointer-events: none;
   &:focus {
     outline: none;
+    pointer-events: all;
     opacity: 1;
   }
   svg {


### PR DESCRIPTION
## For code author
https://scheduleonce.atlassian.net/browse/ONCEHUB-45534
Currently we are facing an accessibility issue i.e. on clicking oui-panel-icon, the close dialog button is visible which is not  an expected behavior. It should be visible only when we are accessing via keyboard.

### What does this PR do?
Under this PR, fixing the above mentioned issue. To fix that issue, we only trap focus if the oui-panel being accessed via keyboard. Removing the pointer events from close panel button to disable get focused via mouse.

### Why do we want to do that?
The close dialog button should be visible only when oui-panel being accessed via keyboard as its part of keyboard accessibility.

### What are the high level changes?
NA
### What other information should the reviewer be aware of when looking at this code?

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
