### PR TITLE
add month name in calendar header and remove month name from month view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "7.0.7-beta.1",
+  "version": "7.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "7.0.7-beta.1",
+      "version": "7.0.7",
       "dependencies": {
         "@angular-devkit/architect": "0.1302.4",
         "@angular-devkit/core": "13.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "7.0.6",
+  "version": "7.0.7-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "7.0.6",
+      "version": "7.0.7-beta.1",
       "dependencies": {
         "@angular-devkit/architect": "0.1302.4",
         "@angular-devkit/core": "13.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "7.0.6",
+  "version": "7.0.7-beta.1",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "7.0.7-beta.1",
+  "version": "7.0.7",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "7.0.7-beta.1",
+  "version": "7.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "7.0.7-beta.1",
+      "version": "7.0.7",
       "dependencies": {
         "tslib": "^2.1.0"
       }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "7.0.6",
+  "version": "7.0.7-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "7.0.6",
+      "version": "7.0.7-beta.1",
       "dependencies": {
         "tslib": "^2.1.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "7.0.7-beta.1",
+  "version": "7.0.7",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "7.0.6",
+  "version": "7.0.7-beta.1",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/src/components/datepicker/calendar-body.html
+++ b/ui/src/components/datepicker/calendar-body.html
@@ -1,18 +1,3 @@
-<!--
-  If there's not enough space in the first row, create a separate label row. We mark this row as
-  aria-hidden because we don't want it to be read out as one of the weeks in the month.
--->
-<tr *ngIf="_firstRowOffset < labelMinRequiredCells" aria-hidden="true">
-  <td
-    class="oui-calendar-body-label"
-    [attr.colspan]="numCols"
-    [style.paddingTop]="_cellPadding"
-    [style.paddingBottom]="_cellPadding"
-  >
-    {{label}}
-  </td>
-</tr>
-
 <!-- Create the first row separately so we can include a special spacer cell. -->
 <tr *ngFor="let row of rows; let rowIndex = index" role="row">
   <!--
@@ -28,9 +13,7 @@
     [attr.colspan]="_firstRowOffset"
     [style.paddingTop]="_cellPadding"
     [style.paddingBottom]="_cellPadding"
-  >
-    {{_firstRowOffset >= labelMinRequiredCells ? label : ''}}
-  </td>
+  ></td>
   <td
     *ngFor="let item of row; let colIndex = index"
     role="gridcell"

--- a/ui/src/components/datepicker/calendar.ts
+++ b/ui/src/components/datepicker/calendar.ts
@@ -333,10 +333,16 @@ export class OuiCalendarHeader<D> {
 
   /** The label for the current calendar view. */
   get periodButtonText(): string {
-    if (
-      this.calendar.currentView === 'month' ||
-      this.calendar.currentView === 'year'
-    ) {
+    if (this.calendar.currentView === 'month') {
+      return (
+        this._dateAdapter.getMonthNames('short')[
+          this._dateAdapter.getMonth(this.calendar.activeDate)
+        ] +
+        ' ' +
+        this._dateAdapter.getYearName(this.calendar.activeDate)
+      );
+    }
+    if (this.calendar.currentView === 'year') {
       return this._dateAdapter.getYearName(this.calendar.activeDate);
     }
     const activeYear = this._dateAdapter.getYear(this.calendar.activeDate);


### PR DESCRIPTION
## For code author
https://scheduleonce.atlassian.net/browse/ONCEHUB-54709
Currently for the oui calendar, month name is not displayed in the calendar header and month name is displayed along with the dates in the month view.

### What does this PR do?

- added month name in calendar header along with the year
- removed month name from month view

### Why do we want to do that?
Display the month name in the calendar header and remove the month name that is displaying along with the dates in the month view.

### What are the high level changes?
NA

### What other information should the reviewer be aware of when looking at this code?
NA

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
