### PR TITLE
Paginator component's hover state is broken

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "7.0.13",
+  "version": "7.0.14-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "7.0.13",
+      "version": "7.0.14-beta.0",
       "dependencies": {
         "@angular-devkit/architect": "0.1302.4",
         "@angular-devkit/core": "13.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "7.0.13",
+  "version": "7.0.14-beta.0",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "7.0.13",
+  "version": "7.0.14-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "7.0.13",
+      "version": "7.0.14-beta.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "7.0.13",
+  "version": "7.0.14-beta.0",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/src/components/paginator/paginator.html
+++ b/ui/src/components/paginator/paginator.html
@@ -2,7 +2,6 @@
   <div class="oui-paginator-container">
     <div class="oui-paginator-range-actions">
       <button
-        oui-button
         class="oui-paginator-navigation-first"
         (click)="firstPage()"
         [attr.aria-label]="_intl.firstPageLabel"
@@ -10,7 +9,6 @@
         [disabled]="_previousButtonsDisabled()"
       ></button>
       <button
-        oui-button
         class="oui-paginator-navigation-previous"
         (click)="previousPage()"
         [attr.aria-label]="_intl.previousPageLabel"
@@ -19,7 +17,6 @@
       ></button>
       <div class="oui-paginator-current-page">{{ getCurrentPage() }}</div>
       <button
-        oui-button
         class="oui-paginator-navigation-next"
         (click)="nextPage()"
         [attr.aria-label]="_intl.nextPageLabel"
@@ -27,7 +24,6 @@
         [disabled]="_nextButtonsDisabled()"
       ></button>
       <button
-        oui-button
         class="oui-paginator-navigation-last"
         (click)="lastPage()"
         [attr.aria-label]="_intl.lastPageLabel"


### PR DESCRIPTION
Ticket: https://scheduleonce.atlassian.net/browse/ONCEHUB-58225

# About the change
We are removing the `oui-button` attribute from the Paginator component. This attribute seems to be doing nothing useful to the component but impacting the UI on the `so-user-frontend` project.