### PR TITLE
Vulnerability fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17524,9 +17524,9 @@
       }
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10"
@@ -51165,9 +51165,9 @@
       "dev": true
     },
     "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true
     },
     "deep-equal": {


### PR DESCRIPTION
**decode-uri-component** vulnerability has been fixed
**@angular-devkit/build-angular, @mdx-js/loader, @mdx-js/mdx, @storybook/addon-docs, @storybook/addon-essentials, @storybook/angular, @storybook/core, @storybook/core-server, @storybook/csf-tools, @storybook/storybook-deployer, chokidar, cpy, fast-glob, git-up, git-url-parse, glob-parent, glob-stream, glob-watcher, globby, gulp, loader-utils, parse-path, parse-url, remark-mdx, remark-parse, trim, vinyl-fs, watchpack, watchpack-chokidar2, webpack** vulnerability not fixed.