### PR TITLE
[ONCEHUB-65725] [app3] Interactions are getting auto populated when we create bot/form from scratch or template and save button is getting enabled in a scenario.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.25] - 2023-03-21
+
+- [ONCEHUB-65275](https://scheduleonce.atlassian.net/browse/ONCEHUB-65725) Interactions are getting auto populated when we create bot/form from scratch or template and save button is getting enabled in a scenario.
+
 ## [7.0.24] - 2023-03-16
 
 - [ONCEHUB-63483](https://scheduleonce.atlassian.net/browse/ONCEHUB-63483) When the user name is entered in the search text field entered username is not able to select the checkbox for the second click of the enter button.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "7.0.24-beta.0",
+  "version": "7.0.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "7.0.24-beta.0",
+      "version": "7.0.25",
       "dependencies": {
         "@angular-devkit/architect": "0.1402.10",
         "@angular-devkit/core": "14.2.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "7.0.24",
+  "version": "7.0.24-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "7.0.24",
+      "version": "7.0.24-beta.0",
       "dependencies": {
         "@angular-devkit/architect": "0.1402.10",
         "@angular-devkit/core": "14.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "7.0.24",
+  "version": "7.0.24-beta.0",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "7.0.24-beta.0",
+  "version": "7.0.25",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "7.0.24-beta.0",
+  "version": "7.0.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "7.0.24-beta.0",
+      "version": "7.0.25",
       "dependencies": {
         "tslib": "^2.1.0"
       }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "7.0.24",
+  "version": "7.0.24-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "7.0.24",
+      "version": "7.0.24-beta.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "7.0.24-beta.0",
+  "version": "7.0.25",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "7.0.24",
+  "version": "7.0.24-beta.0",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/src/components/select/select.component.ts
+++ b/ui/src/components/select/select.component.ts
@@ -666,7 +666,7 @@ export class OuiSelect
     this._panelOpen = true;
     this._keyManager.withHorizontalOrientation(null);
 
-    this._highlightFirstFilteredOption();
+    this._highlightCorrectOption();
     this._changeDetectorRef.markForCheck();
     this.openedChange.emit(true);
     this._elementRef.nativeElement.classList.add(
@@ -973,7 +973,9 @@ export class OuiSelect
         this.ngControl ? this.ngControl.value : this._value
       );
       this.savedValues = this.ngControl ? this.ngControl.value : this._value;
-      this._highlightFirstFilteredOption();
+      if (this.multiple) {
+        this._highlightFirstFilteredOption();
+      }
     });
   }
 
@@ -1170,6 +1172,22 @@ export class OuiSelect
   /** Records option IDs to pass to the aria-owns property. */
   private _setOptionIds() {
     this._optionIds = this.options.map((option) => option.id).join(' ');
+  }
+
+  /**
+   * Highlights the selected item. If no option is selected, it will highlight
+   * the first item instead.
+   */
+  private _highlightCorrectOption(): void {
+    if (this.multiple) {
+      this._highlightFirstFilteredOption();
+    } else if (this._keyManager) {
+      if (this.empty) {
+        this._keyManager.setFirstItemActive();
+      } else {
+        this._keyManager.setActiveItem(this._selectionModel.selected[0]);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## For code author

### What does this PR do?
Limits the logic to highlight first element for multi-selects only

### Why do we want to do that?
To fix known bugs introduced by highlight first element for single selects too

### What are the high level changes?
For single select, old logic is used for highlighting element.
For multi-select, new logic is used to highlight first element.

### What other information should the reviewer be aware of when looking at this code?
Related Issue - [ONCEHUB-65725](https://scheduleonce.atlassian.net/browse/ONCEHUB-65725)

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

[ONCEHUB-65725]: https://scheduleonce.atlassian.net/browse/ONCEHUB-65725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ