### PR TITLE
oui-scrollbar look is broken in Chrome 121

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.9] - 2023-02-09
+
+- [ONCEHUB-78061](https://scheduleonce.atlassian.net/browse/ONCEHUB-78061) Fixed the oui-scrollbar look is broken in Chrome 121
+
 ## [8.0.8] - 2023-02-02
 
 - [ONCEHUB-60767](https://scheduleonce.atlassian.net/browse/ONCEHUB-77583) Add accessibility on oui-panel-icon

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "8.0.8",
+  "version": "8.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "8.0.8",
+      "version": "8.0.9",
       "dependencies": {
         "@angular-devkit/architect": "0.1601.6",
         "@angular-devkit/core": "16.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "8.0.8",
+  "version": "8.0.9",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "8.0.8",
+  "version": "8.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "8.0.8",
+      "version": "8.0.9",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "8.0.8",
+  "version": "8.0.9",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/src/components/scrollbar/scrollbar.scss
+++ b/ui/src/components/scrollbar/scrollbar.scss
@@ -1,23 +1,30 @@
-.oui-scrollbar-container::-webkit-scrollbar {
-  width: 10px;
+.oui-scrollbar-container {
+  overflow-y: auto;
+  &::-webkit-scrollbar {
+    width: 10px;
+  }
+  &::-webkit-scrollbar-track {
+    display: none;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #ccc !important;
+    border: 2px #fff solid;
+    border-radius: 15px;
+  }
 }
-.oui-scrollbar-container::-webkit-scrollbar-track {
-  display: none;
-}
-.oui-scrollbar-container::-webkit-scrollbar-thumb {
-  background-color: #ccc !important;
-  border: 2px #fff solid;
-  border-radius: 15px;
-}
-.oui-scrollbar-container-large::-webkit-scrollbar {
-  width: 16px;
-}
-.oui-scrollbar-container-large::-webkit-scrollbar-thumb {
-  border: 4px #fff solid !important;
+.oui-scrollbar-container-large {
+  &::-webkit-scrollbar {
+    width: 16px;
+  }
+  &::-webkit-scrollbar-thumb {
+    border: 4px #fff solid !important;
+  }
 }
 
 .oui-scrollbar-container {
-  overflow-y: auto;
-  scrollbar-color: #ccc transparent;
-  scrollbar-width: thin;
+  /* Standardized Properties */
+  @supports not selector(::-webkit-scrollbar) {
+    scrollbar-color: #ccc transparent;
+    scrollbar-width: thin;
+  }
 }


### PR DESCRIPTION
## For code author
https://scheduleonce.atlassian.net/browse/ONCEHUB-78061

###  What does this PR do?
The issue stems from two CSS properties causing problems:
- `scrollbar-color: #ccc transparent;`
- `scrollbar-width: thin;`

These properties are applied universally across all browsers in the code, leading to complications. Consequently, we've restricted these properties to Chrome/Edge browsers.

### Why do we want to do that?

### What are the high level changes?

### What other information should the reviewer be aware of when looking at this code?

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes