### PR TITLE
Feat: ONCEHUB-82219 [once-ui] Disable the "Done" button (action items) according to the user's preferences.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "8.0.15",
+  "version": "8.0.16-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "8.0.15",
+      "version": "8.0.16-beta.0",
       "dependencies": {
         "@angular-devkit/architect": "0.1601.6",
         "@angular-devkit/core": "16.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "8.0.15",
+  "version": "8.0.16-beta.0",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "8.0.15",
+  "version": "8.0.16-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "8.0.15",
+      "version": "8.0.16-beta.0",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "8.0.15",
+  "version": "8.0.16-beta.0",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/src/components/select/select.component.ts
+++ b/ui/src/components/select/select.component.ts
@@ -245,6 +245,9 @@ export class OuiSelect
   /** Whether the component is in multiple selection mode. */
   private _multiple = false;
 
+  /** In multiple selection mode, enable Done button even in case of no option selected */
+  private _allowNoSelection = false;
+
   /** Search input field **/
   isSearchFieldPresent: boolean;
 
@@ -508,6 +511,15 @@ export class OuiSelect
     }
 
     this._multiple = coerceBooleanProperty(value);
+  }
+
+  /** Whether the user should be allowed to select no option in case of multiple options. */
+  @Input()
+  get allowNoSelection(): boolean {
+    return this._allowNoSelection;
+  }
+  set allowNoSelection(value: boolean) {
+    this._allowNoSelection = coerceBooleanProperty(value);
   }
 
   /** Whether the action items are required and use saveSelectionChange instead of selectionChange. */
@@ -1219,7 +1231,9 @@ export class OuiSelect
     if (wasSelected !== this._selectionModel.isSelected(option)) {
       this._propagateChanges();
     }
-    this.disableDoneButton = false;
+    if (this.multiple) {
+      this.disableDoneButton = this._isDoneButtonDisabled();
+    }
     this.stateChanges.next();
   }
   discardRecentChanges() {
@@ -1234,6 +1248,18 @@ export class OuiSelect
     this.saveSelectionChange.emit(new OuiSelectChange(this, this.value));
     this.close();
   }
+
+  /** Determine whether the "Done" button should be enabled or disabled based on the selection state */
+  private _isDoneButtonDisabled(): boolean {
+    const selectedItems = (this.selected as OuiOption[]).map(
+      (option) => option.value
+    );
+    if (this.allowNoSelection) {
+      return false;
+    }
+    return selectedItems.length === 0;
+  }
+
   /** Sorts the selected values in the selected based on their order in the panel. */
   private _sortValues() {
     if (this.multiple) {

--- a/ui/src/stories/select/select.stories.mdx
+++ b/ui/src/stories/select/select.stories.mdx
@@ -139,6 +139,7 @@ Multi select:
       ],
       cancelLabel: 'Discard',
       doneLabel: 'Apply',
+      allowNoSelection: false
     }}
     argTypes={{
       theme: {
@@ -158,7 +159,7 @@ Multi select:
       template: `
     <div style="width: 213px;">
     <oui-form-field [appearance]="appearance">
-        <oui-select (saveSelectionChange)="onChange($event)" ngClass="{{theme}}" [large]="large" [placeholder]="placeholder" multiple actionItems [disabled]="disabled" [cancelLabel]="cancelLabel" [doneLabel]="doneLabel">
+        <oui-select (saveSelectionChange)="onChange($event)" ngClass="{{theme}}" [large]="large" [placeholder]="placeholder" multiple actionItems [allowNoSelection]="allowNoSelection" [disabled]="disabled" [cancelLabel]="cancelLabel" [doneLabel]="doneLabel">
           <oui-option *ngFor="let option of options" [value]="option">
             {{option}}
           </oui-option>


### PR DESCRIPTION
https://scheduleonce.atlassian.net/browse/ONCEHUB-82219
Disable the "Done" button (action items) according to the user's preferences.
Feature added:

- Disable the "Done" button if no item is selected from the multi-select list.
- In specific scenarios, the "Done" button remains enabled even when no item is selected from the multi-select list in dropdown.

`<oui-select   [placeholder]="placeholder" multiple [allowNoSelection]="true">`
## For code author

### What does this PR do?

### Why do we want to do that?

### What are the high level changes?

### What other information should the reviewer be aware of when looking at this code?

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
