### PR TITLE
Update npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25551,10 +25551,11 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",


### PR DESCRIPTION
**@angular-devkit/build-angular, @storybook/storybook-deployer, git-up, git-url-parse, http-proxy-middleware, parse-url, puppeteer, puppeteer-core, ws** vulnerability has been fixed
**@angular-devkit/build-angular, @storybook/storybook-deployer, git-up, git-url-parse, http-proxy-middleware, parse-url, puppeteer, puppeteer-core, ws** vulnerability not fixed.