### PR TITLE
Update npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10134,9 +10134,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
**@angular-devkit/build-angular, @storybook/storybook-deployer, cross-spawn, git-up, git-url-parse, http-proxy-middleware, parse-url, puppeteer, puppeteer-core, ws** vulnerability has been fixed
**@angular-devkit/build-angular, @storybook/storybook-deployer, git-up, git-url-parse, http-proxy-middleware, parse-url, puppeteer, puppeteer-core, ws** vulnerability not fixed.