### PR TITLE
remove unsued package @storybook/storybook-deployer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.2] - 2025-06-20
+
+- [ONCEHUB-58683 & ONCEHUB-99063](https://scheduleonce.atlassian.net/browse/ONCEHUB-58683) [ONCE-UI] Remove the unused package @storybook/storybook-deployer
+
 ## [9.0.0] - 2025-04-10
 
 - [ONCEHUB-94991](https://scheduleonce.atlassian.net/browse/ONCEHUB-94991) [ONCE-UI] Upgrade Angular to version 19

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "9.0.2-beat.0",
+  "version": "9.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "9.0.2-beat.0",
+      "version": "9.0.2",
       "dependencies": {
         "@angular-devkit/architect": "0.1902.3",
         "@angular-devkit/core": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "9.0.2-beat.0",
+  "version": "9.0.2",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "9.0.2-beat.0",
+  "version": "9.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "9.0.2-beat.0",
+      "version": "9.0.2",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "9.0.2-beat.0",
+  "version": "9.0.2",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/src/components/autocomplete/autocomplete.html
+++ b/ui/src/components/autocomplete/autocomplete.html
@@ -1,6 +1,6 @@
 <ng-template>
   <div
-    class="oui-autocomplete-panel auto-complete-panel-test"
+    class="oui-autocomplete-panel"
     role="listbox"
     [id]="id"
     [ngClass]="_classList"


### PR DESCRIPTION
This pull request includes changes to prepare the `oncehub-ui` project for the release of version `9.0.2`. Key updates include version bumps across multiple files, the removal of an unused package, and a minor HTML class cleanup in the autocomplete component.

### Version updates:

* Updated the version from `9.0.2-beat.0` to `9.0.2` in `package.json`, `ui/package.json`, and `ui/package-lock.json` to reflect the stable release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L3-R9) [[3]](diffhunk://#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaL3-R3)

### Dependency cleanup:

* Removed the unused package `@storybook/storybook-deployer` as part of the changelog entry for version `9.0.2`.

### Code cleanup:

* Removed the `auto-complete-panel-test` class from the `autocomplete.html` file to simplify the class list for the autocomplete panel.