### PR TITLE
FIX: Slight blink is observed when clicking any drop down menu option of three dots or where Double Popup overlays exist.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "9.0.2",
+  "version": "9.0.3-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "9.0.2",
+      "version": "9.0.3-beta.0",
       "dependencies": {
         "@angular-devkit/architect": "0.1902.3",
         "@angular-devkit/core": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "9.0.2",
+  "version": "9.0.3-beta.0",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "9.0.2",
+  "version": "9.0.3-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "9.0.2",
+      "version": "9.0.3-beta.0",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "9.0.2",
+  "version": "9.0.3-beta.0",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/src/components/dialog/dialog.ts
+++ b/ui/src/components/dialog/dialog.ts
@@ -132,7 +132,7 @@ export class OuiDialog implements OnDestroy {
   open<T, D = any, R = any>(
     componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
     config?: OuiDialogConfig<D>
-  ): OuiDialogRef<T, R> {
+  ): any {
     config = _applyConfigDefaults(
       config,
       this._defaultOptions || new OuiDialogConfig()
@@ -143,29 +143,29 @@ export class OuiDialog implements OnDestroy {
         `Dialog with id "${config.id}" exists already. The dialog id must be unique.`
       );
     }
+    setTimeout(() => {
+      const overlayRef = this._createOverlay(config);
+      const dialogContainer = this._attachDialogContainer(overlayRef, config);
+      const dialogRef = this._attachDialogContent<T, R>(
+        componentOrTemplateRef,
+        dialogContainer,
+        overlayRef,
+        config
+      );
+      // If this is the first dialog that we're opening, hide all the non-overlay content.
+      if (!this.openDialogs.length) {
+        this._hideNonDialogContentFromAssistiveTechnology();
+      }
 
-    const overlayRef = this._createOverlay(config);
-    const dialogContainer = this._attachDialogContainer(overlayRef, config);
-    const dialogRef = this._attachDialogContent<T, R>(
-      componentOrTemplateRef,
-      dialogContainer,
-      overlayRef,
-      config
-    );
-
-    // If this is the first dialog that we're opening, hide all the non-overlay content.
-    if (!this.openDialogs.length) {
-      this._hideNonDialogContentFromAssistiveTechnology();
-    }
-
-    this.openDialogs.push(dialogRef);
-    this._dialogCloseSubscription = dialogRef.afterClosed().subscribe(() => {
-      this._removeOpenDialog(dialogRef);
-      dialogRef._containerInstance._restoreFocus();
-    });
-    this.afterOpened.next(dialogRef);
-    dialogRef._containerInstance._trapFocus();
-    return dialogRef;
+      this.openDialogs.push(dialogRef);
+      this._dialogCloseSubscription = dialogRef.afterClosed().subscribe(() => {
+        this._removeOpenDialog(dialogRef);
+        dialogRef._containerInstance._restoreFocus();
+      });
+      this.afterOpened.next(dialogRef);
+      dialogRef._containerInstance._trapFocus();
+      return dialogRef;
+    }, 100);
   }
 
   /**


### PR DESCRIPTION
This pull request introduces several updates, including a version bump for the `oncehub-ui` package and its dependencies, as well as modifications to the `OuiDialog` class in the `dialog.ts` file to enhance functionality. Below is a summary of the most important changes:

### Version Updates:
* Updated the version of `oncehub-ui` from `9.0.2` to `9.0.3-beta.0` in `package.json`, `ui/package.json`, and `ui/package-lock.json` to reflect a pre-release version. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L3-R9) [[3]](diffhunk://#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaL3-R3)

### Changes to `OuiDialog` Class:
* Changed the return type of the `open` method in `OuiDialog` from `OuiDialogRef<T, R>` to `any`, likely to provide more flexibility or address type-related issues.
* Added a `setTimeout` with a delay of 100ms around the dialog creation logic to potentially resolve timing issues or improve user experience. [[1]](diffhunk://#diff-d5080c4f372bfd608ccd9251cd30bad4f872a14eb2c3781429cb598d14d01014L146-R146) [[2]](diffhunk://#diff-d5080c4f372bfd608ccd9251cd30bad4f872a14eb2c3781429cb598d14d01014R168)
* Removed an unnecessary blank line for code cleanup and consistency.