### PR TITLE
FIX: Slight blink is observed when clicking any drop down menu option of three dots or where Double Popup overlays exist.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "9.0.3-beta.0",
+  "version": "9.0.3-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "9.0.3-beta.0",
+      "version": "9.0.3-beta.1",
       "dependencies": {
         "@angular-devkit/architect": "0.1902.3",
         "@angular-devkit/core": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "9.0.3-beta.0",
+  "version": "9.0.3-beta.1",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "9.0.3-beta.0",
+  "version": "9.0.3-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "9.0.3-beta.0",
+      "version": "9.0.3-beta.1",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "9.0.3-beta.0",
+  "version": "9.0.3-beta.1",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/src/components/dialog/dialog.ts
+++ b/ui/src/components/dialog/dialog.ts
@@ -133,6 +133,12 @@ export class OuiDialog implements OnDestroy {
     componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
     config?: OuiDialogConfig<D>
   ): any {
+    const overlaySelector = document.querySelector(
+      '.cdk-overlay-backdrop-showing'
+    );
+    if (overlaySelector) {
+      (overlaySelector as HTMLElement).style.display = 'none';
+    }
     config = _applyConfigDefaults(
       config,
       this._defaultOptions || new OuiDialogConfig()
@@ -143,29 +149,27 @@ export class OuiDialog implements OnDestroy {
         `Dialog with id "${config.id}" exists already. The dialog id must be unique.`
       );
     }
-    setTimeout(() => {
-      const overlayRef = this._createOverlay(config);
-      const dialogContainer = this._attachDialogContainer(overlayRef, config);
-      const dialogRef = this._attachDialogContent<T, R>(
-        componentOrTemplateRef,
-        dialogContainer,
-        overlayRef,
-        config
-      );
-      // If this is the first dialog that we're opening, hide all the non-overlay content.
-      if (!this.openDialogs.length) {
-        this._hideNonDialogContentFromAssistiveTechnology();
-      }
+    const overlayRef = this._createOverlay(config);
+    const dialogContainer = this._attachDialogContainer(overlayRef, config);
+    const dialogRef = this._attachDialogContent<T, R>(
+      componentOrTemplateRef,
+      dialogContainer,
+      overlayRef,
+      config
+    );
+    // If this is the first dialog that we're opening, hide all the non-overlay content.
+    if (!this.openDialogs.length) {
+      this._hideNonDialogContentFromAssistiveTechnology();
+    }
 
-      this.openDialogs.push(dialogRef);
-      this._dialogCloseSubscription = dialogRef.afterClosed().subscribe(() => {
-        this._removeOpenDialog(dialogRef);
-        dialogRef._containerInstance._restoreFocus();
-      });
-      this.afterOpened.next(dialogRef);
-      dialogRef._containerInstance._trapFocus();
-      return dialogRef;
-    }, 100);
+    this.openDialogs.push(dialogRef);
+    this._dialogCloseSubscription = dialogRef.afterClosed().subscribe(() => {
+      this._removeOpenDialog(dialogRef);
+      dialogRef._containerInstance._restoreFocus();
+    });
+    this.afterOpened.next(dialogRef);
+    dialogRef._containerInstance._trapFocus();
+    return dialogRef;
   }
 
   /**


### PR DESCRIPTION
This pull request includes version updates and enhancements to the `OuiDialog` component in the `@oncehub/ui` package. The most important changes include updating the package version across multiple files and improving the dialog component's behavior by addressing overlay visibility and removing unnecessary delays.

### Version Updates:
* Updated the version from `9.0.3-beta.0` to `9.0.3-beta.1` in `package.json`, `ui/package.json`, and `ui/package-lock.json` to reflect the new release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L3-R9) [[3]](diffhunk://#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaL3-R3)

### Enhancements to `OuiDialog` Component:
* Added logic to hide the `.cdk-overlay-backdrop-showing` element by setting its `display` style to `none` when opening a dialog. This improves the handling of overlay visibility.
* Removed a `setTimeout` block and its associated 100ms delay when creating and attaching the dialog overlay, container, and content. This simplifies the code and eliminates unnecessary asynchronous behavior. [[1]](diffhunk://#diff-d5080c4f372bfd608ccd9251cd30bad4f872a14eb2c3781429cb598d14d01014L146) [[2]](diffhunk://#diff-d5080c4f372bfd608ccd9251cd30bad4f872a14eb2c3781429cb598d14d01014L168)