### PR TITLE
Mavericks/oncehub 96045

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "9.0.3-beta.0",
+  "version": "9.0.3-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "9.0.3-beta.0",
+      "version": "9.0.3-beta.2",
       "dependencies": {
         "@angular-devkit/architect": "0.1902.3",
         "@angular-devkit/core": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "9.0.3-beta.0",
+  "version": "9.0.3-beta.2",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "9.0.3-beta.0",
+  "version": "9.0.3-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "9.0.3-beta.0",
+      "version": "9.0.3-beta.2",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "9.0.3-beta.0",
+  "version": "9.0.3-beta.2",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {


### PR DESCRIPTION
This pull request includes updates to the versioning of the `oncehub-ui` package and its subpackage `@oncehub/ui`, as well as a type improvement in the `OuiDialog` class to enhance type safety.

### Version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the `oncehub-ui` package version from `9.0.3-beta.1` to `9.0.3-beta.2`.
* [`ui/package.json`](diffhunk://#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaL3-R3): Updated the `@oncehub/ui` subpackage version from `9.0.3-beta.1` to `9.0.3-beta.2`.
* [`ui/package-lock.json`](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L3-R9): Updated the version references for `@oncehub/ui` in the lock file from `9.0.3-beta.1` to `9.0.3-beta.2`.

### Type improvements:

* [`ui/src/components/dialog/dialog.ts`](diffhunk://#diff-d5080c4f372bfd608ccd9251cd30bad4f872a14eb2c3781429cb598d14d01014L135-R135): Changed the return type of the `open` method in the `OuiDialog` class from `any` to `OuiDialogRef<T, R>` to improve type safety and provide better developer experience.