### PR TITLE
Update the node version from angular-v20.14.0 to angular-v22.16.0

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -321,7 +321,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: dockeronce.azurecr.io/oncehub/nodejs:angular-v20.14.0
+          image: dockeronce.azurecr.io/oncehub/nodejs:angular-v22.16.0
           name: package-build-publish
           resources: {}
         volumes:


### PR DESCRIPTION
This pull request updates the Node.js Angular version used in the `package-build-publish` step of the Jenkins-X release pipeline.

* [`.lighthouse/jenkins-x/release.yaml`](diffhunk://#diff-5ec41c62ac324ce9007b05ce8ea5d04a25be57b76e035156170736bde9d54a97L324-R324): Updated the Docker image from `angular-v20.14.0` to `angular-v22.16.0` to ensure compatibility with newer Angular features and dependencies.