### PR TITLE
chore: ONCEHUB-112738 update version to 10.0.6-beta.0 and add spellcheck support to input components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "10.0.5",
+  "version": "10.0.6-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "10.0.5",
+      "version": "10.0.6-beta.0",
       "dependencies": {
         "@angular-devkit/architect": "0.2003.4",
         "@angular-devkit/core": "20.3.7",
@@ -1306,6 +1306,24 @@
         "webpack-cli": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@angular-devkit/build-webpack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "10.0.5",
+  "version": "10.0.6-beta.0",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "10.0.5",
+  "version": "10.0.6-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "10.0.5",
+      "version": "10.0.6-beta.0",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "10.0.5",
+  "version": "10.0.6-beta.0",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/src/components/input/input.spec.ts
+++ b/ui/src/components/input/input.spec.ts
@@ -147,7 +147,9 @@ class OuiInputWithoutPlaceholder {}
 
 @Component({
   template: `
-    <oui-form-field><input oui-input [spellcheck]="spellcheck" /></oui-form-field>
+    <oui-form-field
+      ><input oui-input [spellcheck]="spellcheck"
+    /></oui-form-field>
   `,
   standalone: false,
 })

--- a/ui/src/components/input/input.spec.ts
+++ b/ui/src/components/input/input.spec.ts
@@ -145,6 +145,16 @@ class OuiInputWithAppearance {
 })
 class OuiInputWithoutPlaceholder {}
 
+@Component({
+  template: `
+    <oui-form-field><input oui-input [spellcheck]="spellcheck" /></oui-form-field>
+  `,
+  standalone: false,
+})
+class OuiInputWithSpellcheck {
+  spellcheck = true;
+}
+
 describe('OuiInput without forms', () => {
   it('should add id', waitForAsync(() => {
     const fixture = createComponent(OuiInputTextTestController);
@@ -274,6 +284,20 @@ describe('OuiInput without forms', () => {
     const input = fixture.debugElement.query(By.css('input')).nativeElement;
 
     expect(input.hasAttribute('placeholder')).toBe(false);
+  }));
+
+  it('supports the spellcheck attribute as binding', waitForAsync(() => {
+    const fixture = createComponent(OuiInputWithSpellcheck);
+    fixture.detectChanges();
+
+    const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+
+    expect(inputEl.spellcheck).toBe(true);
+
+    fixture.componentInstance.spellcheck = false;
+    fixture.detectChanges();
+
+    expect(inputEl.spellcheck).toBe(false);
   }));
 });
 

--- a/ui/src/components/input/input.ts
+++ b/ui/src/components/input/input.ts
@@ -93,6 +93,8 @@ export const _OuiInputMixinBase: typeof OuiInputBase = mixinColor(OuiInputBase);
     '[attr.aria-describedby]': '_ariaDescribedby || null',
     '[attr.aria-invalid]': 'errorState',
     '[attr.aria-required]': 'required.toString()',
+    // Enable browser's default spellcheck behavior for all text inputs and textareas.
+    '[attr.spellcheck]': 'spellcheck.toString()',
     '(input)': '_onInput()',
   },
   providers: [
@@ -277,6 +279,16 @@ export class OuiInput
     this._readonly = coerceBooleanProperty(value);
   }
   private _readonly = false;
+
+  /** Whether the browser's spellcheck is enabled for the element. */
+  @Input()
+  get spellcheck(): boolean {
+    return this._spellcheck;
+  }
+  set spellcheck(value: boolean) {
+    this._spellcheck = coerceBooleanProperty(value);
+  }
+  private _spellcheck = true;
 
   protected _neverEmptyInputTypes = [
     'date',

--- a/ui/src/stories/form-field/form-field.stories.js
+++ b/ui/src/stories/form-field/form-field.stories.js
@@ -22,7 +22,8 @@ export const Regular = {
                 (focus)="focused()" 
                 [value]="type" 
                 oui-input 
-                [placeholder]="placeholder" /> 
+                [placeholder]="placeholder"
+                [spellcheck]="spellcheck" /> 
                 </oui-form-field>`,
 
     props: {
@@ -50,6 +51,7 @@ export const Regular = {
     disabled: false,
     placeholder: 'Type here',
     appearance: APPEARANCE[0],
+    spellcheck: true,
   },
 
   argTypes: {
@@ -66,6 +68,12 @@ export const Regular = {
 
       control: {
         type: 'select',
+      },
+    },
+
+    spellcheck: {
+      control: {
+        type: 'boolean',
       },
     },
   },

--- a/ui/src/stories/textarea/textarea.stories.js
+++ b/ui/src/stories/textarea/textarea.stories.js
@@ -18,7 +18,7 @@ export const Regular = {
       declarations: [],
     },
 
-    template: `<oui-form-field ngClass="{{theme}}"> <textarea [disabled]="disabled" [rows]="rows" (blur)="blured()" (focus)="focused()" oui-input [placeholder]="placeholder"></textarea> </oui-form-field>`,
+    template: `<oui-form-field ngClass="{{theme}}"> <textarea [disabled]="disabled" [rows]="rows" (blur)="blured()" (focus)="focused()" oui-input [placeholder]="placeholder" [spellcheck]="spellcheck"></textarea> </oui-form-field>`,
 
     props: {
       ...props,
@@ -44,6 +44,7 @@ export const Regular = {
     theme: THEME[0],
     disabled: false,
     placeholder: 'Type here',
+    spellcheck: true,
   },
 
   argTypes: {
@@ -52,6 +53,12 @@ export const Regular = {
 
       control: {
         type: 'select',
+      },
+    },
+
+    spellcheck: {
+      control: {
+        type: 'boolean',
       },
     },
   },


### PR DESCRIPTION
chore: [ONCEHUB-112738](https://scheduleonce.atlassian.net/browse/ONCEHUB-112738) update version to 10.0.6-beta.0 and add spellcheck support to input components


This pull request introduces a new optional `spellcheck` input property to the `OuiInput` component, allowing consumers to control browser spellcheck behavior for text inputs and textareas. The default is enabled, and this property is now surfaced in both the component and its Storybook stories for easier testing and demonstration. Additionally, the package versions are bumped to `10.0.6-beta.0`.

### Input Component Enhancements

* Added a new `spellcheck` input property to the `OuiInput` component (in `input.ts`), defaulting to `true`, allowing developers to enable or disable browser spellcheck on supported input types. The property is now bound to the `spellcheck` attribute in the component template. [[1]](diffhunk://#diff-64e62da76e69986691154b72acad73ec3bef7a1525a09d9543c66140c269d35eR96-R97) [[2]](diffhunk://#diff-64e62da76e69986691154b72acad73ec3bef7a1525a09d9543c66140c269d35eR283-R292)

### Storybook and Demo Updates

* Updated `form-field.stories.js` and `textarea.stories.js` to include the new `spellcheck` input as a controllable prop in the Storybook UI, and passed it to the template for demonstration. [[1]](diffhunk://#diff-db1b3304f4aeac77f4f1f1d666c2e3e71900bc1d1eb367a8d55a30659a5cab9eL25-R26) [[2]](diffhunk://#diff-db1b3304f4aeac77f4f1f1d666c2e3e71900bc1d1eb367a8d55a30659a5cab9eR54) [[3]](diffhunk://#diff-db1b3304f4aeac77f4f1f1d666c2e3e71900bc1d1eb367a8d55a30659a5cab9eR73-R78) [[4]](diffhunk://#diff-8a4945534c4c07f5c51c6a0691463c0bdd1c67d7f752b27084c98a3e42a67512L21-R21) [[5]](diffhunk://#diff-8a4945534c4c07f5c51c6a0691463c0bdd1c67d7f752b27084c98a3e42a67512R47) [[6]](diffhunk://#diff-8a4945534c4c07f5c51c6a0691463c0bdd1c67d7f752b27084c98a3e42a67512R58-R63)

### Package Version Updates

* Bumped versions in `package.json`, `ui/package.json`, and `ui/package-lock.json` from `10.0.5` to `10.0.6-beta.0` to reflect the new feature and changes. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaL3-R3) [[3]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L3-R9)

[ONCEHUB-112738]: https://scheduleonce.atlassian.net/browse/ONCEHUB-112738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ