### PR TITLE
[App2] The Pop up dropdown not close when clicked outside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [11.0.2] - 2026-04-10
+
+- [ONCEHUB-117046](https://scheduleonce.atlassian.net/browse/ONCEHUB-117204) [App2] The Pop up dropdown not close when clicked outside
+
 ## [11.0.1] - 2026-04-08
 
 - [ONCEHUB-117046](https://scheduleonce.atlassian.net/browse/ONCEHUB-117046) [App2] Edit dialog closes when clicking outside, causing unsaved changes to be lost.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.2-beta.0",
+  "version": "11.0.1-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "11.0.2-beta.0",
+      "version": "11.0.1-beta.2",
       "dependencies": {
         "@angular-devkit/architect": "0.2102.7",
         "@angular-devkit/core": "21.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.1-beta.2",
+  "version": "11.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "11.0.1-beta.2",
+      "version": "11.0.2",
       "dependencies": {
         "@angular-devkit/architect": "0.2102.7",
         "@angular-devkit/core": "21.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.2-beta.0",
+  "version": "11.0.1-beta.2",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.1-beta.2",
+  "version": "11.0.2",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.1-beta.2",
+  "version": "11.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "11.0.1-beta.2",
+      "version": "11.0.2",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.2-beta.0",
+  "version": "11.0.1-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "11.0.2-beta.0",
+      "version": "11.0.1-beta.2",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.2-beta.0",
+  "version": "11.0.1-beta.2",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.1-beta.2",
+  "version": "11.0.2",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/src/components/dialog/dialog.scss
+++ b/ui/src/components/dialog/dialog.scss
@@ -10,7 +10,7 @@ $header-icon-height: 24px;
   pointer-events: none;
 }
 .cdk-overlay-backdrop.cdk-overlay-transparent-backdrop {
-  pointer-events: visible;
+  pointer-events: auto;
 }
 .cdk-overlay-pane {
   display: block;

--- a/ui/src/components/dialog/dialog.scss
+++ b/ui/src/components/dialog/dialog.scss
@@ -9,6 +9,9 @@ $header-icon-height: 24px;
   background: rgba(255, 255, 255, 0.8) !important;
   pointer-events: none;
 }
+.cdk-overlay-backdrop.cdk-overlay-transparent-backdrop {
+  pointer-events: visible;
+}
 .cdk-overlay-pane {
   display: block;
 }


### PR DESCRIPTION
This pull request prepares the project for the `11.0.2` production release. It updates version numbers across relevant files, documents the new release in the changelog, and includes a minor CSS fix related to overlay behavior.

Release updates:

* Updated the project version from `11.0.2-beta.0` to `11.0.2` in `package.json`, `ui/package.json`, and `ui/package-lock.json` to reflect the new stable release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaL3-R3) [[3]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L3-R9)
* Added a new entry for version `11.0.2` in `CHANGELOG.md`, documenting the fix for the popup dropdown not closing when clicking outside.

UI bug fix:

* Updated `dialog.scss` to ensure that transparent overlay backdrops allow pointer events, which helps fix issues with popup dropdowns not closing when clicking outside.