### PR TITLE
Updated the once-ui table resizing logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.3-beta.1",
+  "version": "11.0.3-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "11.0.3-beta.1",
+      "version": "11.0.3-beta.2",
       "dependencies": {
         "@angular-devkit/architect": "0.2102.7",
         "@angular-devkit/core": "21.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.3-beta.1",
+  "version": "11.0.3-beta.2",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.3-beta.1",
+  "version": "11.0.3-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "11.0.3-beta.1",
+      "version": "11.0.3-beta.2",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.3-beta.1",
+  "version": "11.0.3-beta.2",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/src/components/sort/sort-header.ts
+++ b/ui/src/components/sort/sort-header.ts
@@ -69,7 +69,7 @@ interface OuiSortHeaderColumnDef {
   templateUrl: 'sort-header.html',
   styleUrls: ['sort-header.scss'],
   host: {
-    '(click)': '_handleClick()',
+    '(click)': '_handleClick($event)',
     '(mouseenter)': '_setIndicatorHintVisible(true)',
     '(longpress)': '_setIndicatorHintVisible(true)',
     '(mouseleave)': '_setIndicatorHintVisible(false)',
@@ -270,8 +270,24 @@ export class OuiSortHeader
   }
 
   /** Triggers the sort on this sort header and removes the indicator hint. */
-  _handleClick() {
+  _handleClick(event: MouseEvent) {
     if (this._isDisabled()) {
+      return;
+    }
+    const target = event.target;
+    if (!(target instanceof Element)) {
+      return;
+    }
+    // Block clicks originating from the resize handle or column menu trigger —
+    // those have their own handlers. Allow clicks anywhere else inside the
+    // sort header container (button text AND the sort arrow).
+    if (
+      target.closest('.oui-col-resize-handle') ||
+      target.closest('.oui-column-menu-trigger')
+    ) {
+      return;
+    }
+    if (!target.closest('.oui-sort-header-container')) {
       return;
     }
 

--- a/ui/src/components/table/column-menu/oui-column-menu.scss
+++ b/ui/src/components/table/column-menu/oui-column-menu.scss
@@ -1,7 +1,7 @@
 // Trigger button styles — appended to th[oui-header-cell] by OuiColumnMenuDirective.
 .oui-column-menu-trigger {
   position: absolute;
-  right: 10px;
+  right: 8px;
   top: 50%;
   transform: translateY(-50%);
   display: none; // shown on hover via oui-header-cell:hover rule below
@@ -122,48 +122,51 @@ th[oui-header-cell]:focus-within .oui-column-menu-trigger,
   outline-offset: 2px;
 }
 
-// Reserve right-hand space so column name text never slides under the ⋮ trigger.
-// Trigger is 20px wide at right:10px → occupies 10–30px from the right edge.
-// User requested a 10px fixed gap between title and the button.
-// Button right (10px) + width (20px) + gap (10px) = 40px total padding.
-oui-header-cell[ouiColumnMenu],
-th[oui-header-cell][ouiColumnMenu] {
-  padding-right: 40px !important;
+// ─── Layout for header cells with column menu ────────────────────────────────
+// NOTE: Do NOT override `display` on <th> in a native HTML table. Changing it
+// from `table-cell` to `flex` causes every flex-th to collapse to the same x
+// position, visually stacking columns on top of each other.
+// Instead we make .oui-sort-header-container inline-flex so the sort indicator
+// button that follows it (rendered with display:contents on its host) flows
+// naturally inline after the title text.
+
+.oui-column-menu-header {
+  padding-right: 36px !important;
   position: relative;
   box-sizing: border-box !important;
-  display: flex !important;
-  align-items: center;
-  overflow: hidden !important;
+  // IMPORTANT: Do not set `display` here. This <th> must remain a native
+  // `table-cell`; changing it to `flex` breaks table layout and can cause
+  // header columns to collapse/stack at the same x position.
 }
 
-// .oui-sort-header-container is the wrapper inside oui-sort-header component.
-// It needs to be a flex container that allows the button to shrink.
-oui-header-cell[ouiColumnMenu] .oui-sort-header-container,
-th[oui-header-cell][ouiColumnMenu] .oui-sort-header-container {
-  display: flex !important;
-  flex-direction: row !important;
+// Make the sort-header container inline so the sort-indicator button sits on
+// the same line as the column title.
+.oui-column-menu-header .oui-sort-header-container {
+  display: inline-flex !important;
   align-items: center !important;
-  width: 100% !important;
-  max-width: 100% !important;
-  min-width: 0 !important; // CRITICAL for shrinking
+  max-width: calc(
+    100% - 30px
+  ) !important; // reserve space for sort indicator + menu trigger
+  vertical-align: middle;
   overflow: hidden !important;
 }
 
-// The button contains the actual text.
-oui-header-cell[ouiColumnMenu] .oui-sort-header-button,
-th[oui-header-cell][ouiColumnMenu] .oui-sort-header-button {
-  display: block !important;
-  flex: 1 1 auto !important;
-  min-width: 0 !important; // Allow shrinking below content width
+// The sort-header button carries the column title text.
+.oui-column-menu-header .oui-sort-header-button {
   overflow: hidden !important;
   text-overflow: ellipsis !important;
   white-space: nowrap !important;
   text-align: left;
 }
 
-// The arrow follows the text and should not shrink.
-oui-header-cell[ouiColumnMenu] .oui-sort-header-arrow,
-th[oui-header-cell][ouiColumnMenu] .oui-sort-header-arrow {
-  flex: 0 0 auto !important;
-  margin-left: 4px;
+// The sort indicator must be inline to sit beside the container.
+.oui-column-menu-header .oui-column-sort-indicator {
+  display: inline-flex !important;
+  vertical-align: middle;
+}
+
+// Hide the built-in oui-sort-header arrow — the column-menu panel's own sort
+// indicator replaces it. Must be display:none so it takes no space.
+.oui-column-menu-header .oui-sort-header-arrow {
+  display: none !important;
 }

--- a/ui/src/components/table/column-reorder/oui-column-reorder.directive.ts
+++ b/ui/src/components/table/column-reorder/oui-column-reorder.directive.ts
@@ -80,6 +80,9 @@ export class OuiReorderableColumnsDirective
   // ─── MutationObserver to auto-refresh when columns re-render ─────────────────
   private _mutationObserver: MutationObserver | null = null;
 
+  // ─── ResizeObserver to detect table overflow and toggle shadow class ─────────
+  private _overflowObserver: ResizeObserver | null = null;
+
   ngAfterViewInit(): void {
     if (!isPlatformBrowser(this._platformId)) {
       return;
@@ -88,6 +91,7 @@ export class OuiReorderableColumnsDirective
       setTimeout(() => {
         this._attachCellListeners();
         this._watchHeaderRow();
+        this._watchOverflow();
       }, 0);
     });
   }
@@ -570,11 +574,37 @@ export class OuiReorderableColumnsDirective
 
   // ─── Cleanup ──────────────────────────────────────────────────────────────────────────────
 
+  // ─── Overflow detection ──────────────────────────────────────────────────────
+
+  private _watchOverflow(): void {
+    const tableEl = this._elementRef.nativeElement;
+    const container = tableEl.parentElement;
+    if (!container) {
+      return;
+    }
+
+    const update = () => {
+      const overflows = container.scrollWidth > container.clientWidth;
+      if (overflows) {
+        this._renderer.addClass(tableEl, 'oui-table-col-overflow');
+      } else {
+        this._renderer.removeClass(tableEl, 'oui-table-col-overflow');
+      }
+    };
+
+    this._overflowObserver = new ResizeObserver(update);
+    this._overflowObserver.observe(container);
+    this._overflowObserver.observe(tableEl);
+    update();
+  }
+
   ngOnDestroy(): void {
     this._detachCellListeners();
     this._clearAllHighlights();
     this._cleanupDragListeners();
     this._mutationObserver?.disconnect();
+    this._overflowObserver?.disconnect();
+    this._overflowObserver = null;
     this._destroyGhost();
     this._destroyDropIndicator();
   }

--- a/ui/src/components/table/column-resize/oui-column-resize.directive.ts
+++ b/ui/src/components/table/column-resize/oui-column-resize.directive.ts
@@ -42,12 +42,16 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
 
   // Drag state
   private _isDragging = false;
+  /** True if the pointer actually moved during the current drag (delta > 2 px). */
+  private _hasMoved = false;
   private _startX = 0;
   private _startWidth = 0;
   /** Minimum width the column is allowed to reach (content + padding, measured at drag-start). */
   private _minCellWidth = 0;
   private _columnId = '';
   private _columnCells: HTMLElement[] = [];
+  /** The header cell being resized — needed to suppress the post-drag click. */
+  private _activeHeaderCell: HTMLElement | null = null;
 
   private _mouseMoveUnlisten: (() => void) | null = null;
   private _mouseUpUnlisten: (() => void) | null = null;
@@ -60,6 +64,11 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
   private _reinitScheduled = false;
   /** Listeners returned by Renderer2.listen for each handle's pointerdown. */
   private _handleUnlisteners: (() => void)[] = [];
+  /** Whether initial column widths have already been snapshotted. */
+  private _initialised = false;
+
+  // ─── ResizeObserver to detect table overflow and toggle shadow class ─────────
+  private _overflowObserver: ResizeObserver | null = null;
 
   ngAfterViewInit(): void {
     if (!isPlatformBrowser(this._platformId)) {
@@ -68,10 +77,54 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     // Defer to allow CDK table to render all header cells.
     this._ngZone.runOutsideAngular(() => {
       setTimeout(() => {
+        this._lockTableLayout();
         this._initHandles();
         this._watchHeaderRow();
+        this._watchOverflow();
       }, 0);
     });
+  }
+
+  /**
+   * For native `<table>` elements, switch to `table-layout: fixed` and
+   * snapshot every column's rendered width. Without this the browser
+   * auto-distributes widths and resize drags are fought by the layout engine.
+   */
+  private _lockTableLayout(): void {
+    if (this._initialised) {
+      return;
+    }
+    this._initialised = true;
+    const host = this._elementRef.nativeElement;
+    const isNativeTable = host.tagName === 'TABLE';
+
+    if (isNativeTable) {
+      this._renderer.setStyle(host, 'table-layout', 'fixed');
+      // Use min-width so the table fills its container but can overflow
+      // when columns are resized to exceed the container width.
+      this._renderer.setStyle(host, 'min-width', '100%');
+      this._renderer.setStyle(host, 'width', 'auto');
+    }
+
+    // Snapshot current rendered widths of every column so they are pinned
+    // before any user interaction. This prevents the browser from re-flowing
+    // columns when one column is resized.
+    const headerCells = Array.from(
+      host.querySelectorAll<HTMLElement>('oui-header-cell, th[oui-header-cell]')
+    );
+    headerCells.forEach((cell) => {
+      const columnId = this._getColumnId(cell);
+      if (columnId && !this._columnWidths.has(columnId)) {
+        const width = cell.getBoundingClientRect().width;
+        const cells = this._getColumnCells(columnId);
+        this._applyWidthToCells(width, cells);
+        this._columnWidths.set(columnId, width);
+      }
+    });
+    // Set an explicit pixel width on the table equal to the sum of all
+    // snapshotted column widths so further resizes that grow beyond the
+    // container can set the table wider than the container.
+    this._syncNativeTableWidth();
   }
 
   /**
@@ -122,6 +175,8 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
       const cells = this._getColumnCells(columnId);
       this._applyWidthToCells(width, cells);
     });
+    // Restore the table's explicit width so it matches the stored column widths.
+    this._syncNativeTableWidth();
   }
 
   private _initHandles(): void {
@@ -173,6 +228,8 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     handle: HTMLElement
   ): void {
     this._isDragging = true;
+    this._hasMoved = false;
+    this._activeHeaderCell = headerCell;
     this._startX = e.clientX;
     this._startWidth = headerCell.getBoundingClientRect().width;
     // scrollWidth = minimum space needed to render content without clipping.
@@ -244,7 +301,17 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
       return;
     }
     const delta = e.clientX - this._startX;
+    if (Math.abs(delta) > 2) {
+      this._hasMoved = true;
+    }
     const newWidth = Math.max(this._minCellWidth, this._startWidth + delta);
+
+    // For native <table> elements, grow (or shrink) the table's explicit width
+    // to match the new sum of all column widths. Without this the browser
+    // re-distributes all columns within the fixed container width, making it
+    // impossible to resize beyond the container boundary.
+    this._syncNativeTableWidth(this._columnId, newWidth);
+
     this._applyWidth(newWidth);
   }
 
@@ -252,8 +319,28 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     if (!this._isDragging) {
       return;
     }
+    const hasMoved = this._hasMoved;
+    const headerCell = this._activeHeaderCell;
+    this._hasMoved = false;
+    this._activeHeaderCell = null;
     this._isDragging = false;
     this._cleanupDragListeners();
+
+    // If the user actually dragged, suppress the click the browser fires after
+    // pointerup — otherwise it would land on the sort header button and
+    // trigger an unwanted sort.
+    if (hasMoved && headerCell) {
+      const suppressClick = (e: MouseEvent) => e.stopPropagation();
+      headerCell.addEventListener('click', suppressClick, {
+        capture: true,
+        once: true,
+      });
+      // Safety: remove if no click follows within 300 ms (pointer left element).
+      setTimeout(
+        () => headerCell.removeEventListener('click', suppressClick, true),
+        300
+      );
+    }
 
     this._renderer.removeClass(
       this._elementRef.nativeElement,
@@ -280,6 +367,8 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
 
     // Persist so we can restore the width if columns are reordered later.
     this._columnWidths.set(this._columnId, finalWidth);
+    // Keep the table's explicit width in sync with the final column widths.
+    this._syncNativeTableWidth();
 
     // Emit inside zone so Angular can run change detection if needed.
     this._ngZone.run(() => {
@@ -320,6 +409,51 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
   }
 
   /**
+   * For native `<table>` elements, sets the table's inline `width` to the
+   * sum of all column widths so the table can overflow its container and
+   * the scroll container shows a horizontal scrollbar.
+   *
+   * Pass `overrideColumnId` + `overrideWidth` to preview a width that
+   * hasn't been committed to `_columnWidths` yet (e.g. during a live drag).
+   * Without arguments the stored widths are summed as-is.
+   *
+   * Has no effect on non-native (CDK/flex) tables.
+   */
+  private _syncNativeTableWidth(
+    overrideColumnId?: string,
+    overrideWidth?: number
+  ): void {
+    const host = this._elementRef.nativeElement;
+    if (host.tagName !== 'TABLE') {
+      return;
+    }
+    let total = 0;
+    this._columnWidths.forEach((w, id) => {
+      total +=
+        id === overrideColumnId && overrideWidth !== undefined
+          ? overrideWidth
+          : w;
+    });
+    // If overrideColumnId is being dragged but not yet in the map (edge case
+    // during very first move), add overrideWidth once.
+    if (
+      overrideColumnId !== undefined &&
+      overrideWidth !== undefined &&
+      !this._columnWidths.has(overrideColumnId)
+    ) {
+      total += overrideWidth;
+    }
+    if (total > 0) {
+      // Use max so the table stays at least as wide as its container.
+      const containerWidth = host.parentElement
+        ? host.parentElement.clientWidth
+        : 0;
+      const tableWidth = Math.max(total, containerWidth);
+      this._renderer.setStyle(host, 'width', `${tableWidth}px`);
+    }
+  }
+
+  /**
    * Apply an explicit width to all cells (header + body) in the column.
    * Since oui-table rows are display:flex, we pin flex properties so that
    * the cell does not grow/shrink beyond the resized width.
@@ -330,12 +464,16 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
 
   private _applyWidthToCells(width: number, cells: HTMLElement[]): void {
     const px = `${width}px`;
+    const isNativeTable = this._elementRef.nativeElement.tagName === 'TABLE';
     cells.forEach((cell) => {
-      this._renderer.setStyle(cell, 'flex', `0 0 ${px}`);
       this._renderer.setStyle(cell, 'width', px);
       this._renderer.setStyle(cell, 'min-width', px);
       this._renderer.setStyle(cell, 'max-width', px);
       this._renderer.setStyle(cell, 'box-sizing', 'border-box');
+      if (!isNativeTable) {
+        // Flex-based rows (oui-table / oui-row) need explicit flex sizing.
+        this._renderer.setStyle(cell, 'flex', `0 0 ${px}`);
+      }
     });
   }
 
@@ -345,9 +483,33 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     this._handles.forEach((h) => h.remove());
     this._handles = [];
     this._mutationObserver?.disconnect();
+    this._overflowObserver?.disconnect();
+    this._overflowObserver = null;
     this._renderer.removeClass(
       this._elementRef.nativeElement,
       'oui-table-resizing'
     );
+  }
+
+  private _watchOverflow(): void {
+    const tableEl = this._elementRef.nativeElement;
+    const container = tableEl.parentElement;
+    if (!container) {
+      return;
+    }
+
+    const update = () => {
+      const overflows = container.scrollWidth > container.clientWidth;
+      if (overflows) {
+        this._renderer.addClass(tableEl, 'oui-table-col-overflow');
+      } else {
+        this._renderer.removeClass(tableEl, 'oui-table-col-overflow');
+      }
+    };
+
+    this._overflowObserver = new ResizeObserver(update);
+    this._overflowObserver.observe(container);
+    this._overflowObserver.observe(tableEl);
+    update();
   }
 }

--- a/ui/src/components/table/oui-table-enhanced-separators.scss
+++ b/ui/src/components/table/oui-table-enhanced-separators.scss
@@ -1,8 +1,3 @@
-// Separator lines for the enhanced table.
-// These only apply when [ouiResizableColumns], [ouiReorderableColumns], or
-// .oui-table-column-menu-enabled is present on the table host element
-// (`oui-table` or `table[oui-table]`).
-
 $oui-enhanced-border-color: #dfdfdf;
 
 oui-table[ouiResizableColumns],
@@ -17,7 +12,7 @@ table[oui-table][ouiReorderableColumns] {
   oui-cell,
   td.oui-cell {
     border-right: 1px solid $oui-enhanced-border-color;
-    position: relative; // Ensure handles/triggers anchor correctly
+    position: relative;
     min-width: 144px !important;
     box-sizing: border-box;
 
@@ -26,22 +21,16 @@ table[oui-table][ouiReorderableColumns] {
     }
   }
 
-  // Ensure last child never has right border even with internal padding rules
   .oui-cell:nth-last-child(1),
   .oui-header-cell:nth-last-child(1) {
     border-right: none !important;
   }
 
-  // Header cell hover background — scoped to enhanced tables only so
-  // the basic/default table appearance is not affected.
   oui-header-cell:hover,
   th.oui-header-cell:hover {
     background: #efefef;
   }
 
-  // ─── Frozen first column ────────────────────────────────────────────────────
-  // The first column stays fixed on horizontal scroll (like Jira).
-  // An opaque background is required so scrolling content doesn't bleed through.
   oui-header-cell:first-child,
   th.oui-header-cell:first-child,
   oui-cell:first-child,
@@ -52,15 +41,19 @@ table[oui-table][ouiReorderableColumns] {
     background: #ffffff;
   }
 
-  // Header cells use the header row background.
   oui-header-cell:first-child,
   th.oui-header-cell:first-child {
     z-index: 3;
     background: #f6f6f6;
   }
+}
 
-  // Subtle shadow on the frozen column's right edge so overlapping content
-  // is clearly hidden behind it.
+// Applied when the table is wider than its container (horizontal scroll exists).
+// The frozen first column gets left/right shadow to visually elevate it.
+oui-table[ouiReorderableColumns].oui-table-col-overflow,
+oui-table[ouiResizableColumns].oui-table-col-overflow,
+table[oui-table][ouiReorderableColumns].oui-table-col-overflow,
+table[oui-table][ouiResizableColumns].oui-table-col-overflow {
   oui-header-cell:first-child::after,
   th.oui-header-cell:first-child::after,
   oui-cell:first-child::after,
@@ -73,5 +66,19 @@ table[oui-table][ouiReorderableColumns] {
     width: 6px;
     pointer-events: none;
     box-shadow: inset 6px 0 6px -6px rgba(0, 0, 0, 0.15);
+  }
+
+  oui-header-cell:first-child::before,
+  th.oui-header-cell:first-child::before,
+  oui-cell:first-child::before,
+  td.oui-cell:first-child::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -6px;
+    bottom: 0;
+    width: 6px;
+    pointer-events: none;
+    box-shadow: inset -6px 0 6px -6px rgba(0, 0, 0, 0.15);
   }
 }

--- a/ui/src/components/table/table.scss
+++ b/ui/src/components/table/table.scss
@@ -97,7 +97,7 @@ oui-footer-cell {
 table.oui-table {
   border-spacing: 0;
   border-collapse: collapse;
-  border-spacing: 0;
+  width: 100%;
 }
 
 tr.oui-header-row {
@@ -134,8 +134,6 @@ tr.oui-row {
     outline: none;
   }
 }
-
-// ─── Column feature enhancements (loaded here because directives can't have styleUrls) ───
 
 @import './column-menu/oui-column-menu';
 @import './column-resize/oui-column-resize';

--- a/ui/src/stories/table/table.component.ts
+++ b/ui/src/stories/table/table.component.ts
@@ -229,7 +229,12 @@ const ENHANCED_DATA = [
 @Component({
   selector: 'oui-table-enhanced-storybook',
   template: `
-    <div class="table-container">
+    <div
+      class="table-container oui-table-enhanced-container tw-overflow-x-auto tw-max-w-full"
+      [class.is-scrolled]="isTableScrolled"
+      [class.table-overflow-shadow]="isTableScrolled"
+      (scroll)="onTableScroll($event)"
+    >
       <table
         oui-table
         [dataSource]="dataSource"
@@ -269,6 +274,7 @@ export class OuiTableEnhancedStorybook implements OnInit {
     ENHANCED_DATA
   );
   lastEvent = '';
+  isTableScrolled = false;
   private readonly ouiIconRegistry = inject(OuiIconRegistry);
   private readonly domSanitizer = inject(DomSanitizer);
 
@@ -287,6 +293,19 @@ export class OuiTableEnhancedStorybook implements OnInit {
 
   onColumnOrderChanged(event: ColumnOrderChangedEvent): void {
     this.displayedColumns = event.columnIds;
+  }
+
+  onTableScroll(event: Event): void {
+    const el = event.target as HTMLElement;
+    this.isTableScrolled = el.scrollLeft > 5;
+  }
+
+  onSort(_event: any): void {
+    // handled by OuiSort + OuiTableDataSource
+  }
+
+  onColumnResized(_event: any): void {
+    // no-op in storybook
   }
 
   onColumnMenuAction(action: ColumnMenuAction): void {

--- a/ui/src/stories/table/table.css
+++ b/ui/src/stories/table/table.css
@@ -1,3 +1,12 @@
+.table-overflow-shadow table tr th:first-child,
+.table-overflow-shadow table tr td:first-child {
+  box-shadow: 0 0 0 2px #bbb, 0 0 8px 2px #bbb;
+  z-index: 2;
+  position: relative;
+}
+.oui-table-enhanced-container {
+  border: 1px solid #dfdfdf;
+}
 .table-container table {
   width: 99%;
 }


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the table and column resize functionality, enhances the column menu and sort header integration, and updates package versions. The changes focus on ensuring that column resizing works seamlessly with native HTML tables, preventing unwanted sorts after a resize, and refining the layout and styling of table headers with column menus.

**Table Column Resize and Layout Enhancements:**

* Improved native `<table>` column resizing: The directive now locks the table layout to `table-layout: fixed`, snapshots column widths, and manages the table's width so it can overflow its container and be scrollable. This ensures that resizing columns behaves correctly and the table doesn't collapse or redistribute columns unexpectedly. (`ui/src/components/table/column-resize/oui-column-resize.directive.ts`) [[1]](diffhunk://#diff-b1e99a030f332a8d1802bc87cbb925feeceebb8612fa9b7fcfd6e5fb15ade503R77-R125) [[2]](diffhunk://#diff-b1e99a030f332a8d1802bc87cbb925feeceebb8612fa9b7fcfd6e5fb15ade503R174-R175) [[3]](diffhunk://#diff-b1e99a030f332a8d1802bc87cbb925feeceebb8612fa9b7fcfd6e5fb15ade503R300-R340) [[4]](diffhunk://#diff-b1e99a030f332a8d1802bc87cbb925feeceebb8612fa9b7fcfd6e5fb15ade503R366-R367) [[5]](diffhunk://#diff-b1e99a030f332a8d1802bc87cbb925feeceebb8612fa9b7fcfd6e5fb15ade503R407-R451)
* Suppressed unwanted sort after resize: When a column is resized, the next click event on the header cell is suppressed to prevent accidental sorting triggered by the mouseup event after a drag. (`ui/src/components/table/column-resize/oui-column-resize.directive.ts`)
* Ensured correct flex and width styles: The code now applies `flex` styles only for flex-based tables, not native tables, to avoid breaking native table layouts. (`ui/src/components/table/column-resize/oui-column-resize.directive.ts`)
* Set table width to 100% by default for better layout. (`ui/src/components/table/table.scss`)

**Sort Header and Column Menu Integration:**

* Updated sort header click handling to only trigger sort when clicking the actual button, preventing sorts from clicks in empty space or after a resize. (`ui/src/components/sort/sort-header.ts`) [[1]](diffhunk://#diff-837f28703b6d2873c94ef3ef6d1dcde6af18ec441bab24bf6b87d8616318a31cL72-R72) [[2]](diffhunk://#diff-837f28703b6d2873c94ef3ef6d1dcde6af18ec441bab24bf6b87d8616318a31cL273-R281)
* Added a stable CSS class (`oui-column-menu-header`) for header cells with column menus, allowing for more robust styling and layout targeting. (`ui/src/components/table/column-menu/oui-column-menu.directive.ts`)
* Refined column menu and sort header layout: Adjusted right padding, container flex behavior, and sort indicator display to ensure proper alignment and prevent layout issues when both sorting and column menu are present. (`ui/src/components/table/column-menu/oui-column-menu.scss`) [[1]](diffhunk://#diff-bdf5313ea6e47d9949549d1d1e49ba0b44cc2087f66383e3fbfe9c8db7cb26e6L4-R4) [[2]](diffhunk://#diff-bdf5313ea6e47d9949549d1d1e49ba0b44cc2087f66383e3fbfe9c8db7cb26e6L125-R169)

**Storybook and Demo Updates:**

* Enhanced the table storybook example to make the table horizontally scrollable, track scroll state, and improve the demonstration of the new behaviors. (`ui/src/stories/table/table.component.ts`) [[1]](diffhunk://#diff-17e18bc202dc06685ab52ce34bde35116a99b2313fe0ae02d289da3a1676c0c8L232-R235) [[2]](diffhunk://#diff-17e18bc202dc06685ab52ce34bde35116a99b2313fe0ae02d289da3a1676c0c8R275) [[3]](diffhunk://#diff-17e18bc202dc06685ab52ce34bde35116a99b2313fe0ae02d289da3a1676c0c8R296-R308)

**Version Bumps:**

* Bumped package versions to `11.0.3-beta.2` in `package.json`, `ui/package.json`, and `ui/package-lock.json` to reflect the new release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaL3-R3) [[3]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L3-R9)