### PR TITLE
Updated the resizing issue and reordering highlight issue on the table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.4",
+  "version": "11.0.5.beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "11.0.4",
+      "version": "11.0.5.beta.0",
       "dependencies": {
         "@angular-devkit/architect": "0.2102.7",
         "@angular-devkit/core": "21.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.4",
+  "version": "11.0.5.beta.0",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.4",
+  "version": "11.0.5.beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "11.0.4",
+      "version": "11.0.5.beta.0",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.4",
+  "version": "11.0.5.beta.0",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/src/components/table/column-reorder/oui-column-reorder.directive.ts
+++ b/ui/src/components/table/column-reorder/oui-column-reorder.directive.ts
@@ -50,7 +50,6 @@ export class OuiReorderableColumnsDirective
   /** True while _onPointerUp is running — prevents lostpointercapture from re-entering cleanup. */
   private _pointerUpInProgress = false;
   private _sourceIndex = -1;
-  private _currentTargetIndex = -1;
   private _startX = 0;
   private _startY = 0;
   /** Offset from cursor to cell left edge at pointerdown — keeps ghost pinned under cursor horizontally. */
@@ -60,6 +59,11 @@ export class OuiReorderableColumnsDirective
   private _columnIds: string[] = [];
   /** CDK column ID of the currently highlighted target column. */
   private _highlightedTargetColumnId = '';
+  /**
+   * The insertion slot index: the column will be inserted BEFORE this index.
+   * A value equal to _headerCells.length means "insert at the very end".
+   */
+  private _insertionSlot = -1;
   private _ghost: HTMLElement | null = null;
   private _dropIndicator: HTMLElement | null = null;
 
@@ -115,11 +119,15 @@ export class OuiReorderableColumnsDirective
           if (idx === 0) {
             return;
           }
-          // Skip resize handle and ⋮ menu trigger — those have their own handlers.
+          // Skip resize handle, ⋮ menu trigger, and sort indicator —
+          // those have their own click handlers. setPointerCapture must not
+          // be called on these targets or the browser re-routes the click to
+          // the <th> (the captured element), preventing their handlers from firing.
           const target = e.target as HTMLElement;
           if (
-            target.classList.contains('oui-col-resize-handle') ||
-            target.classList.contains('oui-column-menu-trigger')
+            target.closest('.oui-col-resize-handle') ||
+            target.closest('.oui-column-menu-trigger') ||
+            target.closest('.oui-column-sort-indicator')
           ) {
             return;
           }
@@ -167,11 +175,10 @@ export class OuiReorderableColumnsDirective
     this._dragging = false;
     this._dragActive = true;
     this._sourceIndex = cellIndex;
-    this._currentTargetIndex = cellIndex;
     this._startX = e.clientX;
     this._startY = e.clientY;
 
-    // Capture cursor offset within the cell so the ghost stays pinned where the user grabbed.
+    // Capture cursor offset within the cell so the ghost stays pinned under the cursor.
     const cellRect = cell.getBoundingClientRect();
     this._cursorOffsetX = e.clientX - cellRect.left;
     this._cursorOffsetY = e.clientY - cellRect.top;
@@ -256,20 +263,32 @@ export class OuiReorderableColumnsDirective
       }
     }
 
-    // Ghost follows the cursor freely in both X and Y (Jira-like floating chip).
+    // Ghost follows the cursor freely in both X and Y.
+    // Only the height is pinned to the table height.
     if (this._ghost) {
+      const tableRect = this._elementRef.nativeElement.getBoundingClientRect();
+      const bounds = this._getVisibleBounds(tableRect);
+      // Ghost follows the cursor freely in both X and Y —
+      // only its height is locked to the visible table height.
       const ghostX = e.clientX - this._cursorOffsetX;
       const ghostY = e.clientY - this._cursorOffsetY;
+
       this._renderer.setStyle(
         this._ghost,
         'transform',
         `translate(${ghostX}px, ${ghostY}px)`
       );
+      // Keep ghost height equal to the visible table height.
+      this._renderer.setStyle(
+        this._ghost,
+        'height',
+        `${bounds.bottom - bounds.top}px`
+      );
     }
 
-    this._currentTargetIndex = this._getTargetIndex(e.clientX);
-    this._positionDropIndicator(this._currentTargetIndex, e.clientX);
-    this._updateTargetHighlight(this._currentTargetIndex, e.clientX, e.clientY);
+    this._insertionSlot = this._getInsertionSlot(e.clientX);
+    const isOverTable = this._isCursorOverHeaderCell(e.clientX, e.clientY);
+    this._positionDropIndicator(this._insertionSlot, isOverTable);
   }
 
   private _onPointerUp(_e: PointerEvent): void {
@@ -313,25 +332,62 @@ export class OuiReorderableColumnsDirective
       return;
     }
 
-    const prev = this._sourceIndex;
-    const curr = this._currentTargetIndex;
+    // After a real drag, suppress the click event that the browser fires
+    // immediately after pointerup. Without this, releasing the pointer
+    // over the sort indicator fires onSortClick and triggers an unintended sort.
+    // Use document-level capture to intercept regardless of which element
+    // the click is dispatched to (varies by browser / capture state).
+    const suppressDragClick = (evt: MouseEvent) => {
+      evt.stopImmediatePropagation();
+      evt.preventDefault();
+    };
+    document.addEventListener('click', suppressDragClick, {
+      capture: true,
+      once: true,
+    });
+    // Safety: remove the suppressor if no click fires within 300ms.
+    setTimeout(
+      () => document.removeEventListener('click', suppressDragClick, true),
+      300
+    );
 
-    // Only reorder if cursor is directly over a different header cell.
+    const prev = this._sourceIndex;
+
+    // Valid drop: cursor is over a header cell and the insertion slot would
+    // actually move the column (not a no-op).
+    const isNoOp =
+      this._insertionSlot === prev || this._insertionSlot === prev + 1;
     const validDrop =
-      prev !== curr && this._isCursorOverHeaderCell(_e.clientX, _e.clientY);
+      !isNoOp && this._isCursorOverHeaderCell(_e.clientX, _e.clientY);
 
     if (validDrop) {
-      const newOrder = [...this._columnIds];
-      const [moved] = newOrder.splice(prev, 1);
-      newOrder.splice(curr, 0, moved);
+      // Convert the insertion slot to a final index in the original array.
+      // _insertionSlot is the slot index in the current column order.
+      // When the source is before the slot, removing it shifts all later
+      // indices down by one, so we subtract 1 from the slot.
+      let finalIndex = this._insertionSlot;
+      if (prev < finalIndex) {
+        finalIndex -= 1;
+      }
+      // Clamp to valid range after removal.
+      finalIndex = Math.max(
+        0,
+        Math.min(finalIndex, this._columnIds.length - 1)
+      );
 
-      this._ngZone.run(() => {
-        this.columnOrderChanged.emit({
-          previousIndex: prev,
-          currentIndex: curr,
-          columnIds: newOrder,
+      if (prev !== finalIndex) {
+        const newOrder = [...this._columnIds];
+        const [moved] = newOrder.splice(prev, 1);
+        newOrder.splice(finalIndex, 0, moved);
+
+        this._ngZone.run(() => {
+          this.columnOrderChanged.emit({
+            previousIndex: prev,
+            currentIndex: finalIndex,
+            columnIds: newOrder,
+          });
         });
-      });
+      }
     }
   }
 
@@ -379,6 +435,57 @@ export class OuiReorderableColumnsDirective
 
   // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+  /**
+   * Returns the visible bounds of the table, intersected with the nearest
+   * scroll ancestor AND the viewport so drag visuals never escape the
+   * visible area — even when the page itself is the scroll context.
+   */
+  private _getVisibleBounds(tableRect: DOMRect): {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+  } {
+    const bounds = {
+      left: tableRect.left,
+      top: tableRect.top,
+      right: tableRect.right,
+      bottom: tableRect.bottom,
+    };
+
+    // Walk up to find the nearest scroll ancestor and clamp to its rect.
+    const scrollParent = this._findScrollParent(this._elementRef.nativeElement);
+    if (scrollParent) {
+      const sr = scrollParent.getBoundingClientRect();
+      bounds.left = Math.max(bounds.left, sr.left);
+      bounds.top = Math.max(bounds.top, sr.top);
+      bounds.right = Math.min(bounds.right, sr.right);
+      bounds.bottom = Math.min(bounds.bottom, sr.bottom);
+    }
+
+    // Always clamp to the viewport as a final safety net (handles
+    // page-level scrolling where no scroll ancestor exists).
+    bounds.left = Math.max(bounds.left, 0);
+    bounds.top = Math.max(bounds.top, 0);
+    bounds.right = Math.min(bounds.right, globalThis.innerWidth);
+    bounds.bottom = Math.min(bounds.bottom, globalThis.innerHeight);
+
+    return bounds;
+  }
+
+  /** Walk up the DOM to find the nearest ancestor with overflow scrolling. */
+  private _findScrollParent(el: HTMLElement): HTMLElement | null {
+    let parent = el.parentElement;
+    while (parent && parent !== document.documentElement) {
+      const style = globalThis.getComputedStyle(parent);
+      if (/(auto|scroll|hidden)/.test(style.overflowY)) {
+        return parent;
+      }
+      parent = parent.parentElement;
+    }
+    return null;
+  }
+
   private _getColumnId(cell: HTMLElement): string {
     const cls = Array.from(cell.classList).find((c) =>
       c.startsWith('cdk-column-')
@@ -399,23 +506,31 @@ export class OuiReorderableColumnsDirective
     });
   }
 
-  private _getTargetIndex(clientX: number): number {
-    let best = this._sourceIndex;
-    let bestDist = Infinity;
-    this._headerCells.forEach((cell, idx) => {
-      // First column is locked — never allow dropping onto it.
-      if (idx === 0) {
-        return;
+  /**
+   * Calculate the insertion slot index — the position BEFORE which the
+   * dragged column will be inserted. This is edge-based, not center-based:
+   * the cursor position relative to each column boundary determines the slot.
+   *
+   * Returns a value in [1, _headerCells.length] (slot 0 = before the locked
+   * first column, which is never valid).
+   */
+  private _getInsertionSlot(clientX: number): number {
+    const tableRect = this._elementRef.nativeElement.getBoundingClientRect();
+    const bounds = this._getVisibleBounds(tableRect);
+    const clampedX = Math.max(bounds.left, Math.min(clientX, bounds.right));
+
+    // Walk the header cells and find which gap the cursor falls into.
+    // A "gap" is between the midpoint of column N and the midpoint of column N+1.
+    // If cursor is left of the first movable column's midpoint → slot = 1.
+    // If cursor is right of the last column's midpoint → slot = length.
+    for (let i = 1; i < this._headerCells.length; i++) {
+      const rect = this._headerCells[i].getBoundingClientRect();
+      const mid = rect.left + rect.width / 2;
+      if (clampedX < mid) {
+        return i;
       }
-      const rect = cell.getBoundingClientRect();
-      const center = rect.left + rect.width / 2;
-      const dist = Math.abs(clientX - center);
-      if (dist < bestDist) {
-        bestDist = dist;
-        best = idx;
-      }
-    });
-    return best;
+    }
+    return this._headerCells.length;
   }
 
   // ─── Ghost ────────────────────────────────────────────────────────────────────
@@ -424,17 +539,22 @@ export class OuiReorderableColumnsDirective
     const source = this._headerCells[this._sourceIndex];
     const cellRect = source.getBoundingClientRect();
     const tableRect = this._elementRef.nativeElement.getBoundingClientRect();
+    const bounds = this._getVisibleBounds(tableRect);
 
     this._ghost = this._renderer.createElement('div') as HTMLElement;
     this._renderer.addClass(this._ghost, 'oui-col-reorder-ghost');
-    // Full column size: same width as source header, full table height.
+    // Full column size: same width as source header, height clipped to visible table area.
     this._renderer.setStyle(this._ghost, 'width', `${cellRect.width}px`);
-    this._renderer.setStyle(this._ghost, 'height', `${tableRect.height}px`);
-    // Start at source column, top of table.
+    this._renderer.setStyle(
+      this._ghost,
+      'height',
+      `${bounds.bottom - bounds.top}px`
+    );
+    // Start at source column, top of visible table area.
     this._renderer.setStyle(
       this._ghost,
       'transform',
-      `translate(${cellRect.left}px, ${tableRect.top}px)`
+      `translate(${cellRect.left}px, ${bounds.top}px)`
     );
     this._renderer.appendChild(document.body, this._ghost);
   }
@@ -454,28 +574,52 @@ export class OuiReorderableColumnsDirective
     this._renderer.appendChild(document.body, this._dropIndicator);
   }
 
-  private _positionDropIndicator(targetIndex: number, clientX: number): void {
+  /**
+   * Position the drop indicator at the insertion slot boundary.
+   * The slot index points BEFORE a column, so we use the left edge of
+   * that column — or the right edge of the last column for the end slot.
+   */
+  private _positionDropIndicator(slot: number, visible: boolean): void {
     if (!this._dropIndicator) {
       return;
     }
-    const targetCell = this._headerCells[targetIndex];
-    if (!targetCell) {
+    // Hide when cursor is outside the table header area, or when the
+    // insertion slot equals the source (no-op drop).
+    const isNoOp = slot === this._sourceIndex || slot === this._sourceIndex + 1;
+    if (!visible || isNoOp) {
+      this._renderer.setStyle(this._dropIndicator, 'display', 'none');
       return;
     }
-    const rect = targetCell.getBoundingClientRect();
+    this._renderer.setStyle(this._dropIndicator, 'display', '');
+
     const tableRect = this._elementRef.nativeElement.getBoundingClientRect();
-    const mid = rect.left + rect.width / 2;
-    const xPos = clientX < mid ? rect.left : rect.right;
+    const bounds = this._getVisibleBounds(tableRect);
+    const indicatorWidth = 2;
+
+    let rawX: number;
+    if (slot >= this._headerCells.length) {
+      // Insert at the very end — use right edge of last column.
+      const lastCell = this._headerCells[this._headerCells.length - 1];
+      rawX = lastCell.getBoundingClientRect().right;
+    } else {
+      // Insert before column at `slot` — use its left edge.
+      rawX = this._headerCells[slot].getBoundingClientRect().left;
+    }
+
+    const xPos = Math.max(
+      bounds.left,
+      Math.min(rawX, bounds.right - indicatorWidth)
+    );
 
     this._renderer.setStyle(
       this._dropIndicator,
       'transform',
-      `translate(${xPos}px, ${tableRect.top}px)`
+      `translate(${xPos}px, ${bounds.top}px)`
     );
     this._renderer.setStyle(
       this._dropIndicator,
       'height',
-      `${tableRect.height}px`
+      `${bounds.bottom - bounds.top}px`
     );
   }
 
@@ -500,41 +644,6 @@ export class OuiReorderableColumnsDirective
           ? this._renderer.addClass(cell, cls)
           : this._renderer.removeClass(cell, cls)
       );
-  }
-
-  /** Update which target column is highlighted as the pointer moves. */
-  private _updateTargetHighlight(
-    targetIndex: number,
-    clientX: number,
-    clientY: number
-  ): void {
-    const isOverHeader = this._isCursorOverHeaderCell(clientX, clientY);
-    const targetCell = targetIndex >= 0 ? this._headerCells[targetIndex] : null;
-    const targetId =
-      isOverHeader && targetCell ? this._getColumnId(targetCell) : '';
-    const sourceId =
-      this._sourceIndex >= 0 ? this._columnIds[this._sourceIndex] : '';
-
-    if (targetId === this._highlightedTargetColumnId) {
-      return;
-    }
-
-    // Clear previous target highlight.
-    if (this._highlightedTargetColumnId) {
-      this._applyColumnClass(
-        this._highlightedTargetColumnId,
-        'oui-col-reorder-target',
-        false
-      );
-    }
-
-    // Apply new target highlight, unless it is the source column itself or cursor is not over header.
-    if (targetId && targetId !== sourceId) {
-      this._applyColumnClass(targetId, 'oui-col-reorder-target', true);
-      this._highlightedTargetColumnId = targetId;
-    } else {
-      this._highlightedTargetColumnId = '';
-    }
   }
 
   /** Remove all drag-related highlight classes from the table. */

--- a/ui/src/components/table/column-reorder/oui-column-reorder.scss
+++ b/ui/src/components/table/column-reorder/oui-column-reorder.scss
@@ -95,8 +95,13 @@ table[oui-table][ouiReorderableColumns] th[oui-header-cell]:not(:first-child) {
 }
 
 // Drop indicator: thin vertical line at the drop target edge.
+// left:0;top:0 is required so that transform:translate(x,y) positions
+// the element from the viewport origin rather than from its auto static
+// position (which varies depending on the amount of content in the page).
 .oui-col-reorder-indicator {
   position: fixed;
+  left: 0;
+  top: 0;
   width: 2px;
   background: $_drag-blue-line;
   border-radius: 1px;

--- a/ui/src/components/table/column-resize/oui-column-resize.directive.ts
+++ b/ui/src/components/table/column-resize/oui-column-resize.directive.ts
@@ -125,6 +125,14 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     // snapshotted column widths so further resizes that grow beyond the
     // container can set the table wider than the container.
     this._syncNativeTableWidth();
+    // Remove min-width now that we have an explicit pixel width on the table.
+    // Keeping min-width: 100% would override the explicit width whenever the
+    // column sum drops below the container width, causing table-layout:fixed
+    // to redistribute the surplus pixels across ALL columns — exactly the
+    // bidirectional-shift bug. The scroll container handles overflow instead.
+    if (isNativeTable) {
+      this._renderer.removeStyle(host, 'min-width');
+    }
   }
 
   /**
@@ -444,12 +452,13 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
       total += overrideWidth;
     }
     if (total > 0) {
-      // Use max so the table stays at least as wide as its container.
-      const containerWidth = host.parentElement
-        ? host.parentElement.clientWidth
-        : 0;
-      const tableWidth = Math.max(total, containerWidth);
-      this._renderer.setStyle(host, 'width', `${tableWidth}px`);
+      // Set the table to exactly the sum of column widths — no Math.max with
+      // containerWidth. If the table were wider than the column sum,
+      // table-layout:fixed would proportionally distribute the surplus to all
+      // columns, shifting columns the user did not touch. The scroll container
+      // (overflow-x: auto) handles horizontal overflow when columns grow past
+      // the container, and shows a gap at the right when they shrink below it.
+      this._renderer.setStyle(host, 'width', `${total}px`);
     }
   }
 


### PR DESCRIPTION
This pull request introduces significant improvements to the column reorder and resize functionality in the UI table components, focusing on more precise drag-and-drop behavior, better visual feedback, and improved handling of table layout and resizing. The changes include both TypeScript and SCSS updates, as well as package version bumps.

**Key improvements:**

### Column Reorder Functionality

* Refactored the drag-and-drop logic in `OuiReorderableColumnsDirective` to use an "insertion slot" approach for determining where to insert the dragged column, ensuring more intuitive and accurate column placement. The drop indicator and ghost elements now strictly adhere to visible table bounds, improving usability in scrollable and partially visible tables. [[1]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeL53) [[2]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeR62-R66) [[3]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeL170) [[4]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeL259-R285) [[5]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeL317-R364) [[6]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeR410-R462) [[7]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeL402-R507) [[8]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeR516-R531) [[9]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeL457-R597) [[10]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeL505-L538)

* Updated related SCSS to ensure drag visuals (ghost, drop indicator, and highlights) are clipped to the visible area and styled more consistently. [[1]](diffhunk://#diff-9d43457c8d629e9e0ab32218d50bdef793cf2b69544d0e70afaaba5e5b930e26R30-R37) [[2]](diffhunk://#diff-9d43457c8d629e9e0ab32218d50bdef793cf2b69544d0e70afaaba5e5b930e26R60) [[3]](diffhunk://#diff-9d43457c8d629e9e0ab32218d50bdef793cf2b69544d0e70afaaba5e5b930e26R102-R103)

### Column Resize Functionality

* Fixed table layout issues by removing the forced `min-width: 100%` style, preventing unwanted column shifting during resize.

* Improved pointerup and click handling in `OuiResizableColumnsDirective` to suppress unwanted sort toggling after a resize and to reset column width on click without drag. [[1]](diffhunk://#diff-b1e99a030f332a8d1802bc87cbb925feeceebb8612fa9b7fcfd6e5fb15ade503L329-L344) [[2]](diffhunk://#diff-b1e99a030f332a8d1802bc87cbb925feeceebb8612fa9b7fcfd6e5fb15ade503R346-R365)

### Package Version Updates

* Bumped the version of the main package and UI subpackage to `11.0.5-beta.0` to reflect these changes. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L3-R9) [[3]](diffhunk://#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaL3-R3)