### PR TITLE
updated the package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.5.beta.0",
+  "version": "11.0.5-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "11.0.5.beta.0",
+      "version": "11.0.5-beta.0",
       "dependencies": {
         "@angular-devkit/architect": "0.2102.7",
         "@angular-devkit/core": "21.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.5.beta.0",
+  "version": "11.0.5-beta.0",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.5.beta.0",
+  "version": "11.0.5-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "11.0.5.beta.0",
+      "version": "11.0.5-beta.0",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.5.beta.0",
+  "version": "11.0.5-beta.0",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {


### PR DESCRIPTION
This pull request updates the versioning format across the project from using a dot-separated pre-release version (e.g., `11.0.5.beta.0`) to a hyphen-separated format (e.g., `11.0.5-beta.0`). This aligns the versioning with standard npm and semantic versioning practices.

Versioning updates:

* Changed the version in the root `package.json` from `11.0.5.beta.0` to `11.0.5-beta.0` to follow semantic versioning conventions.
* Updated the version in `ui/package.json` from `11.0.5.beta.0` to `11.0.5-beta.0`.
* Updated all relevant version references in `ui/package-lock.json` from `11.0.5.beta.0` to `11.0.5-beta.0`.