### PR TITLE
Enhance column resizing functionality with improved width management and elastic column behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [11.0.5] - 2026-05-12
+
+- [ONCEHUB-115012](https://scheduleonce.atlassian.net/browse/ONCEHUB-115012) [ONCE-UI] [Table] Updated Interactive Table resize improvements.
+
 ## [11.0.4] - 2026-04-28
 
 - [ONCEHUB-117481](https://scheduleonce.atlassian.net/browse/ONCEHUB-117481) [ONCE-UI] [Table] Added Interactive Table features (Resize, Reorder, and Column Menu).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.4",
+  "version": "11.0.5.beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "11.0.4",
+      "version": "11.0.5.beta.0",
       "dependencies": {
         "@angular-devkit/architect": "0.2102.7",
         "@angular-devkit/core": "21.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.5.beta.0",
+  "version": "11.0.5-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "11.0.5.beta.0",
+      "version": "11.0.5-beta.0",
       "dependencies": {
         "@angular-devkit/architect": "0.2102.7",
         "@angular-devkit/core": "21.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.5-beta.0",
+  "version": "11.0.5-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "11.0.5-beta.0",
+      "version": "11.0.5-beta.1",
       "dependencies": {
         "@angular-devkit/architect": "0.2102.7",
         "@angular-devkit/core": "21.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.5-beta.1",
+  "version": "11.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "11.0.5-beta.1",
+      "version": "11.0.5",
       "dependencies": {
         "@angular-devkit/architect": "0.2102.7",
         "@angular-devkit/core": "21.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.5.beta.0",
+  "version": "11.0.5-beta.0",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.5-beta.1",
+  "version": "11.0.5",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.5-beta.0",
+  "version": "11.0.5-beta.1",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "11.0.4",
+  "version": "11.0.5.beta.0",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.5-beta.1",
+  "version": "11.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "11.0.5-beta.1",
+      "version": "11.0.5",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.4",
+  "version": "11.0.5.beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "11.0.4",
+      "version": "11.0.5.beta.0",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.5-beta.0",
+  "version": "11.0.5-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "11.0.5-beta.0",
+      "version": "11.0.5-beta.1",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.5.beta.0",
+  "version": "11.0.5-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "11.0.5.beta.0",
+      "version": "11.0.5-beta.0",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.5-beta.0",
+  "version": "11.0.5-beta.1",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.4",
+  "version": "11.0.5.beta.0",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.5.beta.0",
+  "version": "11.0.5-beta.0",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.0.5-beta.1",
+  "version": "11.0.5",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/src/components/table/column-menu/oui-column-menu-panel.component.html
+++ b/ui/src/components/table/column-menu/oui-column-menu-panel.component.html
@@ -15,13 +15,12 @@
   "
 >
   @if (sortDirection === 'asc') {
-  <oui-icon svgIcon="move-up" size="13" class="oui-column-sort-icon"></oui-icon>
+
+  <div class="oui-column-sort-indicator--sorting"></div>
   } @else {
-  <oui-icon
-    svgIcon="move-down"
-    size="13"
-    class="oui-column-sort-icon"
-  ></oui-icon>
+  <div
+    class="oui-column-sort-indicator--sorting oui-column-sort-indicator--sorting--desc"
+  ></div>
   }
 </button>
 }

--- a/ui/src/components/table/column-menu/oui-column-menu-panel.component.html
+++ b/ui/src/components/table/column-menu/oui-column-menu-panel.component.html
@@ -6,12 +6,19 @@
   type="button"
   [class.oui-column-sort-active]="sortDirection"
   (click)="onSortClick($event)"
+  [ouiTooltip]="
+    sortDirection === 'asc'
+      ? 'Sorted ascending'
+      : sortDirection === 'desc'
+      ? 'Sorted descending'
+      : 'Sort ascending'
+  "
   [attr.aria-label]="
     sortDirection === 'asc'
-      ? 'Sort descending'
+      ? 'Sort ascending'
       : sortDirection === 'desc'
       ? 'Clear sort'
-      : 'Sort ascending'
+      : 'Sort descending'
   "
 >
   @if (sortDirection === 'asc') {
@@ -43,12 +50,12 @@
   @if (!isFirst && !isSecond) {
   <button oui-menu-item (click)="select('moveLeft')">
     <oui-icon svgIcon="move_left" class="oui-column-menu-icon"></oui-icon>
-    <span>Move column to left</span>
+    <span>Move to left</span>
   </button>
   } @if (!isFirst && !isLast) {
   <button oui-menu-item (click)="select('moveRight')">
     <oui-icon svgIcon="move_right" class="oui-column-menu-icon"></oui-icon>
-    <span>Move column to right</span>
+    <span>Move to right</span>
   </button>
   }
 

--- a/ui/src/components/table/column-menu/oui-column-menu-panel.component.html
+++ b/ui/src/components/table/column-menu/oui-column-menu-panel.component.html
@@ -15,10 +15,10 @@
   "
   [attr.aria-label]="
     sortDirection === 'asc'
-      ? 'Sort ascending'
+      ? 'Sort descending'
       : sortDirection === 'desc'
       ? 'Clear sort'
-      : 'Sort descending'
+      : 'Sort ascending'
   "
 >
   @if (sortDirection === 'asc') {

--- a/ui/src/components/table/column-menu/oui-column-menu.scss
+++ b/ui/src/components/table/column-menu/oui-column-menu.scss
@@ -51,6 +51,8 @@
 // ─── Sort indicator (beside column title) ─────────────────────────────────────
 // Clicking cycles through asc → desc → cleared, matching oui-sort-header behavior.
 
+$arrow-sorting: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMTAwJSIgd2lkdGg9IjEwMCUiIGZpdD0iIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCBtZWV0IiBmb2N1c2FibGU9ImZhbHNlIiB2aWV3Qm94PSI0LjE5ODk5OTQwNDkwNzIyNyAxLjEwMDAwMDM4MTQ2OTcyNjYgMTEuNjQ1MDAwNDU3NzYzNjcyIDE2LjkzNDk5OTQ2NTk0MjM4MyI+PHBhdGggZD0iTTQuOTA2IDcuNjNsNS4xMTYtNS4xMTYgNS4xMTUgNS4xMTYgMC43MDctMC43MDctNS44MjItNS44MjMtNS44MjMgNS44MjMgMC43MDcgMC43MDd6Ij48L3BhdGg+PHBhdGggZD0iTTkuNSAxOC4wMzVoMXYtMTZoLTF2MTZ6Ij48L3BhdGg+PC9zdmc+');
+
 .oui-column-sort-indicator {
   display: inline-flex;
   align-items: center;
@@ -72,6 +74,17 @@
     width: 12px;
     height: 12px;
     color: #8c8c8c; // faded hint color when not sorted
+  }
+
+  &--sorting {
+    width: 12px;
+    height: 12px;
+    background: $arrow-sorting center center no-repeat;
+    display: inline-block;
+
+    &--desc {
+      transform: scaleY(-1);
+    }
   }
 
   // When actively sorted, show darker icon.

--- a/ui/src/components/table/column-reorder/oui-column-reorder.directive.ts
+++ b/ui/src/components/table/column-reorder/oui-column-reorder.directive.ts
@@ -50,7 +50,6 @@ export class OuiReorderableColumnsDirective
   /** True while _onPointerUp is running — prevents lostpointercapture from re-entering cleanup. */
   private _pointerUpInProgress = false;
   private _sourceIndex = -1;
-  private _currentTargetIndex = -1;
   private _startX = 0;
   private _startY = 0;
   /** Offset from cursor to cell left edge at pointerdown — keeps ghost pinned under cursor horizontally. */
@@ -60,6 +59,11 @@ export class OuiReorderableColumnsDirective
   private _columnIds: string[] = [];
   /** CDK column ID of the currently highlighted target column. */
   private _highlightedTargetColumnId = '';
+  /**
+   * The insertion slot index: the column will be inserted BEFORE this index.
+   * A value equal to _headerCells.length means "insert at the very end".
+   */
+  private _insertionSlot = -1;
   private _ghost: HTMLElement | null = null;
   private _dropIndicator: HTMLElement | null = null;
 
@@ -115,11 +119,15 @@ export class OuiReorderableColumnsDirective
           if (idx === 0) {
             return;
           }
-          // Skip resize handle and ⋮ menu trigger — those have their own handlers.
+          // Skip resize handle, ⋮ menu trigger, and sort indicator —
+          // those have their own click handlers. setPointerCapture must not
+          // be called on these targets or the browser re-routes the click to
+          // the <th> (the captured element), preventing their handlers from firing.
           const target = e.target as HTMLElement;
           if (
-            target.classList.contains('oui-col-resize-handle') ||
-            target.classList.contains('oui-column-menu-trigger')
+            target.closest('.oui-col-resize-handle') ||
+            target.closest('.oui-column-menu-trigger') ||
+            target.closest('.oui-column-sort-indicator')
           ) {
             return;
           }
@@ -167,11 +175,10 @@ export class OuiReorderableColumnsDirective
     this._dragging = false;
     this._dragActive = true;
     this._sourceIndex = cellIndex;
-    this._currentTargetIndex = cellIndex;
     this._startX = e.clientX;
     this._startY = e.clientY;
 
-    // Capture cursor offset within the cell so the ghost stays pinned where the user grabbed.
+    // Capture cursor offset within the cell so the ghost stays pinned under the cursor.
     const cellRect = cell.getBoundingClientRect();
     this._cursorOffsetX = e.clientX - cellRect.left;
     this._cursorOffsetY = e.clientY - cellRect.top;
@@ -256,20 +263,32 @@ export class OuiReorderableColumnsDirective
       }
     }
 
-    // Ghost follows the cursor freely in both X and Y (Jira-like floating chip).
+    // Ghost follows the cursor freely in both X and Y.
+    // Only the height is pinned to the table height.
     if (this._ghost) {
+      const tableRect = this._elementRef.nativeElement.getBoundingClientRect();
+      const bounds = this._getVisibleBounds(tableRect);
+      // Ghost follows the cursor freely in both X and Y —
+      // only its height is locked to the visible table height.
       const ghostX = e.clientX - this._cursorOffsetX;
       const ghostY = e.clientY - this._cursorOffsetY;
+
       this._renderer.setStyle(
         this._ghost,
         'transform',
         `translate(${ghostX}px, ${ghostY}px)`
       );
+      // Keep ghost height equal to the visible table height.
+      this._renderer.setStyle(
+        this._ghost,
+        'height',
+        `${bounds.bottom - bounds.top}px`
+      );
     }
 
-    this._currentTargetIndex = this._getTargetIndex(e.clientX);
-    this._positionDropIndicator(this._currentTargetIndex, e.clientX);
-    this._updateTargetHighlight(this._currentTargetIndex, e.clientX, e.clientY);
+    this._insertionSlot = this._getInsertionSlot(e.clientX);
+    const isOverTable = this._isCursorOverHeaderCell(e.clientX, e.clientY);
+    this._positionDropIndicator(this._insertionSlot, isOverTable);
   }
 
   private _onPointerUp(_e: PointerEvent): void {
@@ -313,25 +332,62 @@ export class OuiReorderableColumnsDirective
       return;
     }
 
-    const prev = this._sourceIndex;
-    const curr = this._currentTargetIndex;
+    // After a real drag, suppress the click event that the browser fires
+    // immediately after pointerup. Without this, releasing the pointer
+    // over the sort indicator fires onSortClick and triggers an unintended sort.
+    // Use document-level capture to intercept regardless of which element
+    // the click is dispatched to (varies by browser / capture state).
+    const suppressDragClick = (evt: MouseEvent) => {
+      evt.stopImmediatePropagation();
+      evt.preventDefault();
+    };
+    document.addEventListener('click', suppressDragClick, {
+      capture: true,
+      once: true,
+    });
+    // Safety: remove the suppressor if no click fires within 300ms.
+    setTimeout(
+      () => document.removeEventListener('click', suppressDragClick, true),
+      300
+    );
 
-    // Only reorder if cursor is directly over a different header cell.
+    const prev = this._sourceIndex;
+
+    // Valid drop: cursor is over a header cell and the insertion slot would
+    // actually move the column (not a no-op).
+    const isNoOp =
+      this._insertionSlot === prev || this._insertionSlot === prev + 1;
     const validDrop =
-      prev !== curr && this._isCursorOverHeaderCell(_e.clientX, _e.clientY);
+      !isNoOp && this._isCursorOverHeaderCell(_e.clientX, _e.clientY);
 
     if (validDrop) {
-      const newOrder = [...this._columnIds];
-      const [moved] = newOrder.splice(prev, 1);
-      newOrder.splice(curr, 0, moved);
+      // Convert the insertion slot to a final index in the original array.
+      // _insertionSlot is the slot index in the current column order.
+      // When the source is before the slot, removing it shifts all later
+      // indices down by one, so we subtract 1 from the slot.
+      let finalIndex = this._insertionSlot;
+      if (prev < finalIndex) {
+        finalIndex -= 1;
+      }
+      // Clamp to valid range after removal.
+      finalIndex = Math.max(
+        0,
+        Math.min(finalIndex, this._columnIds.length - 1)
+      );
 
-      this._ngZone.run(() => {
-        this.columnOrderChanged.emit({
-          previousIndex: prev,
-          currentIndex: curr,
-          columnIds: newOrder,
+      if (prev !== finalIndex) {
+        const newOrder = [...this._columnIds];
+        const [moved] = newOrder.splice(prev, 1);
+        newOrder.splice(finalIndex, 0, moved);
+
+        this._ngZone.run(() => {
+          this.columnOrderChanged.emit({
+            previousIndex: prev,
+            currentIndex: finalIndex,
+            columnIds: newOrder,
+          });
         });
-      });
+      }
     }
   }
 
@@ -379,6 +435,57 @@ export class OuiReorderableColumnsDirective
 
   // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+  /**
+   * Returns the visible bounds of the table, intersected with the nearest
+   * scroll ancestor AND the viewport so drag visuals never escape the
+   * visible area — even when the page itself is the scroll context.
+   */
+  private _getVisibleBounds(tableRect: DOMRect): {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+  } {
+    const bounds = {
+      left: tableRect.left,
+      top: tableRect.top,
+      right: tableRect.right,
+      bottom: tableRect.bottom,
+    };
+
+    // Walk up to find the nearest scroll ancestor and clamp to its rect.
+    const scrollParent = this._findScrollParent(this._elementRef.nativeElement);
+    if (scrollParent) {
+      const sr = scrollParent.getBoundingClientRect();
+      bounds.left = Math.max(bounds.left, sr.left);
+      bounds.top = Math.max(bounds.top, sr.top);
+      bounds.right = Math.min(bounds.right, sr.right);
+      bounds.bottom = Math.min(bounds.bottom, sr.bottom);
+    }
+
+    // Always clamp to the viewport as a final safety net (handles
+    // page-level scrolling where no scroll ancestor exists).
+    bounds.left = Math.max(bounds.left, 0);
+    bounds.top = Math.max(bounds.top, 0);
+    bounds.right = Math.min(bounds.right, globalThis.innerWidth);
+    bounds.bottom = Math.min(bounds.bottom, globalThis.innerHeight);
+
+    return bounds;
+  }
+
+  /** Walk up the DOM to find the nearest ancestor with overflow scrolling. */
+  private _findScrollParent(el: HTMLElement): HTMLElement | null {
+    let parent = el.parentElement;
+    while (parent && parent !== document.documentElement) {
+      const style = globalThis.getComputedStyle(parent);
+      if (/(auto|scroll|hidden)/.test(style.overflowY)) {
+        return parent;
+      }
+      parent = parent.parentElement;
+    }
+    return null;
+  }
+
   private _getColumnId(cell: HTMLElement): string {
     const cls = Array.from(cell.classList).find((c) =>
       c.startsWith('cdk-column-')
@@ -399,23 +506,31 @@ export class OuiReorderableColumnsDirective
     });
   }
 
-  private _getTargetIndex(clientX: number): number {
-    let best = this._sourceIndex;
-    let bestDist = Infinity;
-    this._headerCells.forEach((cell, idx) => {
-      // First column is locked — never allow dropping onto it.
-      if (idx === 0) {
-        return;
+  /**
+   * Calculate the insertion slot index — the position BEFORE which the
+   * dragged column will be inserted. This is edge-based, not center-based:
+   * the cursor position relative to each column boundary determines the slot.
+   *
+   * Returns a value in [1, _headerCells.length] (slot 0 = before the locked
+   * first column, which is never valid).
+   */
+  private _getInsertionSlot(clientX: number): number {
+    const tableRect = this._elementRef.nativeElement.getBoundingClientRect();
+    const bounds = this._getVisibleBounds(tableRect);
+    const clampedX = Math.max(bounds.left, Math.min(clientX, bounds.right));
+
+    // Walk the header cells and find which gap the cursor falls into.
+    // A "gap" is between the midpoint of column N and the midpoint of column N+1.
+    // If cursor is left of the first movable column's midpoint → slot = 1.
+    // If cursor is right of the last column's midpoint → slot = length.
+    for (let i = 1; i < this._headerCells.length; i++) {
+      const rect = this._headerCells[i].getBoundingClientRect();
+      const mid = rect.left + rect.width / 2;
+      if (clampedX < mid) {
+        return i;
       }
-      const rect = cell.getBoundingClientRect();
-      const center = rect.left + rect.width / 2;
-      const dist = Math.abs(clientX - center);
-      if (dist < bestDist) {
-        bestDist = dist;
-        best = idx;
-      }
-    });
-    return best;
+    }
+    return this._headerCells.length;
   }
 
   // ─── Ghost ────────────────────────────────────────────────────────────────────
@@ -424,17 +539,22 @@ export class OuiReorderableColumnsDirective
     const source = this._headerCells[this._sourceIndex];
     const cellRect = source.getBoundingClientRect();
     const tableRect = this._elementRef.nativeElement.getBoundingClientRect();
+    const bounds = this._getVisibleBounds(tableRect);
 
     this._ghost = this._renderer.createElement('div') as HTMLElement;
     this._renderer.addClass(this._ghost, 'oui-col-reorder-ghost');
-    // Full column size: same width as source header, full table height.
+    // Full column size: same width as source header, height clipped to visible table area.
     this._renderer.setStyle(this._ghost, 'width', `${cellRect.width}px`);
-    this._renderer.setStyle(this._ghost, 'height', `${tableRect.height}px`);
-    // Start at source column, top of table.
+    this._renderer.setStyle(
+      this._ghost,
+      'height',
+      `${bounds.bottom - bounds.top}px`
+    );
+    // Start at source column, top of visible table area.
     this._renderer.setStyle(
       this._ghost,
       'transform',
-      `translate(${cellRect.left}px, ${tableRect.top}px)`
+      `translate(${cellRect.left}px, ${bounds.top}px)`
     );
     this._renderer.appendChild(document.body, this._ghost);
   }
@@ -454,28 +574,52 @@ export class OuiReorderableColumnsDirective
     this._renderer.appendChild(document.body, this._dropIndicator);
   }
 
-  private _positionDropIndicator(targetIndex: number, clientX: number): void {
+  /**
+   * Position the drop indicator at the insertion slot boundary.
+   * The slot index points BEFORE a column, so we use the left edge of
+   * that column — or the right edge of the last column for the end slot.
+   */
+  private _positionDropIndicator(slot: number, visible: boolean): void {
     if (!this._dropIndicator) {
       return;
     }
-    const targetCell = this._headerCells[targetIndex];
-    if (!targetCell) {
+    // Hide when cursor is outside the table header area, or when the
+    // insertion slot equals the source (no-op drop).
+    const isNoOp = slot === this._sourceIndex || slot === this._sourceIndex + 1;
+    if (!visible || isNoOp) {
+      this._renderer.setStyle(this._dropIndicator, 'display', 'none');
       return;
     }
-    const rect = targetCell.getBoundingClientRect();
+    this._renderer.setStyle(this._dropIndicator, 'display', '');
+
     const tableRect = this._elementRef.nativeElement.getBoundingClientRect();
-    const mid = rect.left + rect.width / 2;
-    const xPos = clientX < mid ? rect.left : rect.right;
+    const bounds = this._getVisibleBounds(tableRect);
+    const indicatorWidth = 2;
+
+    let rawX: number;
+    if (slot >= this._headerCells.length) {
+      // Insert at the very end — use right edge of last column.
+      const lastCell = this._headerCells[this._headerCells.length - 1];
+      rawX = lastCell.getBoundingClientRect().right;
+    } else {
+      // Insert before column at `slot` — use its left edge.
+      rawX = this._headerCells[slot].getBoundingClientRect().left;
+    }
+
+    const xPos = Math.max(
+      bounds.left,
+      Math.min(rawX, bounds.right - indicatorWidth)
+    );
 
     this._renderer.setStyle(
       this._dropIndicator,
       'transform',
-      `translate(${xPos}px, ${tableRect.top}px)`
+      `translate(${xPos}px, ${bounds.top}px)`
     );
     this._renderer.setStyle(
       this._dropIndicator,
       'height',
-      `${tableRect.height}px`
+      `${bounds.bottom - bounds.top}px`
     );
   }
 
@@ -500,41 +644,6 @@ export class OuiReorderableColumnsDirective
           ? this._renderer.addClass(cell, cls)
           : this._renderer.removeClass(cell, cls)
       );
-  }
-
-  /** Update which target column is highlighted as the pointer moves. */
-  private _updateTargetHighlight(
-    targetIndex: number,
-    clientX: number,
-    clientY: number
-  ): void {
-    const isOverHeader = this._isCursorOverHeaderCell(clientX, clientY);
-    const targetCell = targetIndex >= 0 ? this._headerCells[targetIndex] : null;
-    const targetId =
-      isOverHeader && targetCell ? this._getColumnId(targetCell) : '';
-    const sourceId =
-      this._sourceIndex >= 0 ? this._columnIds[this._sourceIndex] : '';
-
-    if (targetId === this._highlightedTargetColumnId) {
-      return;
-    }
-
-    // Clear previous target highlight.
-    if (this._highlightedTargetColumnId) {
-      this._applyColumnClass(
-        this._highlightedTargetColumnId,
-        'oui-col-reorder-target',
-        false
-      );
-    }
-
-    // Apply new target highlight, unless it is the source column itself or cursor is not over header.
-    if (targetId && targetId !== sourceId) {
-      this._applyColumnClass(targetId, 'oui-col-reorder-target', true);
-      this._highlightedTargetColumnId = targetId;
-    } else {
-      this._highlightedTargetColumnId = '';
-    }
   }
 
   /** Remove all drag-related highlight classes from the table. */

--- a/ui/src/components/table/column-reorder/oui-column-reorder.scss
+++ b/ui/src/components/table/column-reorder/oui-column-reorder.scss
@@ -95,8 +95,13 @@ table[oui-table][ouiReorderableColumns] th[oui-header-cell]:not(:first-child) {
 }
 
 // Drop indicator: thin vertical line at the drop target edge.
+// left:0;top:0 is required so that transform:translate(x,y) positions
+// the element from the viewport origin rather than from its auto static
+// position (which varies depending on the amount of content in the page).
 .oui-col-reorder-indicator {
   position: fixed;
+  left: 0;
+  top: 0;
   width: 2px;
   background: $_drag-blue-line;
   border-radius: 1px;

--- a/ui/src/components/table/column-resize/oui-column-resize.directive.ts
+++ b/ui/src/components/table/column-resize/oui-column-resize.directive.ts
@@ -27,12 +27,20 @@ export interface ColumnResizeEvent {
 })
 export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
   /**
-   * Minimum column width in pixels. Defaults to 0 (natural min-content width is the floor).
-   * Consumers can pass a specific value to prevent columns from becoming too narrow.
+   * Minimum column width in pixels. Must be a positive number; if 0 or negative
+   * the directive falls back to 200px.
    */
   @Input() minColumnWidth = 0;
 
-  /** Emitted when the user finishes resizing a column. */
+  /**
+   * Optional initial column widths keyed by CDK column ID.
+   * Supports two-way binding: `[(columnWidths)]="widthMap"` keeps the parent
+   * in sync as the user resizes columns or columns are added/removed.
+   */
+  @Input() columnWidths: Record<string, number> = {};
+  @Output() columnWidthsChange = new EventEmitter<Record<string, number>>();
+
+  /** Emitted when the user finishes resizing a single column. */
   @Output() columnResized = new EventEmitter<ColumnResizeEvent>();
 
   private _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
@@ -60,15 +68,53 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
   private _activeHandle: HTMLElement | null = null;
   /** Persists user-resized widths by column ID so they survive column reorder. */
   private _columnWidths = new Map<string, number>();
+  /** Tracks columns that the user has explicitly resized (vs auto-snapshotted at render). */
+  private _userResizedColumns = new Set<string>();
   private _mutationObserver: MutationObserver | null = null;
   private _reinitScheduled = false;
   /** Listeners returned by Renderer2.listen for each handle's pointerdown. */
   private _handleUnlisteners: (() => void)[] = [];
   /** Whether initial column widths have already been snapshotted. */
   private _initialised = false;
+  /** rAF handle for the pending double-rAF retry inside _reapplyStoredWidths. */
+  private _pendingApplyRaf: number | null = null;
+  /**
+   * The rightmost column that is NOT being dragged. During a drag it acts as
+   * an elastic column: it shrinks when the dragged column expands (absorbing
+   * overflow) and grows when the dragged column shrinks (filling the freed
+   * space), keeping the table at exactly containerWidth in both directions.
+   * Only active when the table initially fits the container (_elasticEnabled).
+   */
+  private _elasticColumnId = '';
+  private _elasticColumnStartWidth = 0;
+  private _elasticColumnWasUserResized = false;
+  /** True when table fits container at drag-start (no scrollbar). */
+  private _elasticEnabled = false;
+  /**
+   * The measured content+padding minimum for the elastic column, computed at
+   * drag-start. Used as the floor instead of effectiveMinWidth when the elastic
+   * column started below effectiveMinWidth (e.g. equal-division columns).
+   */
+  private _elasticColumnMinWidth = 0;
+  /**
+   * Columns that the user has explicitly drag-resized during this session.
+   * Only these are included in `columnWidthsChange` emissions so that the
+   * parent's persisted map never gets overwritten by auto-calculated widths
+   * (last-column fill, equal-division, column add/remove redistribution).
+   */
+  private _dragResizedColumns = new Set<string>();
+  /** Unique ID stamped on the table host to scope the injected stylesheet. */
+  private _tableId = `oui-table-${Math.random().toString(36).slice(2, 9)}`;
+  /** <style> element that holds per-column CSS rules, eliminating render flicker. */
+  private _styleEl: HTMLStyleElement | null = null;
 
   // ─── ResizeObserver to detect table overflow and toggle shadow class ─────────
   private _overflowObserver: ResizeObserver | null = null;
+
+  /** Effective minimum width: the input value when positive, otherwise 200px. */
+  private get _effectiveMinWidth(): number {
+    return this.minColumnWidth > 0 ? this.minColumnWidth : 200;
+  }
 
   ngAfterViewInit(): void {
     if (!isPlatformBrowser(this._platformId)) {
@@ -98,6 +144,18 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     const host = this._elementRef.nativeElement;
     const isNativeTable = host.tagName === 'TABLE';
 
+    // Stamp a unique ID so the injected stylesheet can be scoped to this table.
+    this._renderer.setAttribute(host, 'data-oui-resize-id', this._tableId);
+    this._initStyleSheet();
+
+    // Measure all header cells BEFORE switching to table-layout:fixed.
+    // After the switch the browser may compute 0px for columns with no
+    // intrinsic content width (e.g. a single-column table), so we always
+    // take the measurement from the auto-layout pass.
+    const headerCells = Array.from(
+      host.querySelectorAll<HTMLElement>('oui-header-cell, th[oui-header-cell]')
+    );
+
     if (isNativeTable) {
       this._renderer.setStyle(host, 'table-layout', 'fixed');
       // Use min-width so the table fills its container but can overflow
@@ -106,33 +164,84 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
       this._renderer.setStyle(host, 'width', 'auto');
     }
 
-    // Snapshot current rendered widths of every column so they are pinned
-    // before any user interaction. This prevents the browser from re-flowing
-    // columns when one column is resized.
-    const headerCells = Array.from(
-      host.querySelectorAll<HTMLElement>('oui-header-cell, th[oui-header-cell]')
-    );
+    // Apply widths using consumer-supplied overrides or effectiveMinWidth.
+    // The last column is intentionally left for _fillRemainingToLastColumn to
+    // expand so it covers all unused container space.
+    // Fallback chain per column (highest → lowest priority):
+    //   1. Consumer-supplied `columnWidths` input (if positive)
+    //   2. _effectiveMinWidth  (no equal-division; last column fills the rest)
     headerCells.forEach((cell) => {
       const columnId = this._getColumnId(cell);
       if (columnId && !this._columnWidths.has(columnId)) {
-        const width = cell.getBoundingClientRect().width;
+        const inputWidth = this.columnWidths[columnId];
+        const width =
+          inputWidth != null && inputWidth > 0
+            ? inputWidth
+            : this._effectiveMinWidth;
+        // Mark every initially-rendered column as user-resized so that a
+        // later dynamic column addition does not shrink any of them back to
+        // effectiveMinWidth. The last column will still be expanded by
+        // _fillRemainingToLastColumn, but that extra space is tracked via
+        // _columnWidths and stays stable across add/remove cycles.
+        this._userResizedColumns.add(columnId);
         const cells = this._getColumnCells(columnId);
         this._applyWidthToCells(width, cells);
         this._columnWidths.set(columnId, width);
       }
     });
+    // If the total of snapshotted widths is less than the container width,
+    // absorb the remainder into the last column so the table fills exactly.
+    this._fillRemainingToLastColumn(headerCells);
     // Set an explicit pixel width on the table equal to the sum of all
     // snapshotted column widths so further resizes that grow beyond the
     // container can set the table wider than the container.
-    this._syncNativeTableWidth();
+    this._syncTableWidth();
     // Remove min-width now that we have an explicit pixel width on the table.
     // Keeping min-width: 100% would override the explicit width whenever the
     // column sum drops below the container width, causing table-layout:fixed
     // to redistribute the surplus pixels across ALL columns — exactly the
     // bidirectional-shift bug. The scroll container handles overflow instead.
-    if (isNativeTable) {
-      this._renderer.removeStyle(host, 'min-width');
+    // if (isNativeTable) {
+    //   this._renderer.removeStyle(host, 'min-width');
+    // }
+    this._updateStyleSheet();
+    // Do not emit here — init widths are auto-calculated, not user-driven.
+  }
+
+  /**
+   * Distributes any unused container space to the last column in DOM order.
+   * Called after snapshotting (or reconciling) column widths to ensure the
+   * table always fills its container without leaving a gap on the right.
+   */
+  private _fillRemainingToLastColumn(headerCells: HTMLElement[]): void {
+    const host = this._elementRef.nativeElement;
+    const containerWidth = host.parentElement
+      ? host.parentElement.clientWidth
+      : 0;
+    if (containerWidth === 0) {
+      return;
     }
+    let total = 0;
+    this._columnWidths.forEach((w) => (total += w));
+    const remaining = containerWidth - total;
+    if (remaining <= 0) {
+      return;
+    }
+    let lastColumnId = '';
+    for (let i = headerCells.length - 1; i >= 0; i--) {
+      const id = this._getColumnId(headerCells[i]);
+      if (id && this._columnWidths.has(id)) {
+        lastColumnId = id;
+        break;
+      }
+    }
+    if (!lastColumnId) {
+      return;
+    }
+    const newWidth = (this._columnWidths.get(lastColumnId) ?? 0) + remaining;
+    const cells = this._getColumnCells(lastColumnId);
+    this._applyWidthToCells(newWidth, cells);
+    this._columnWidths.set(lastColumnId, newWidth);
   }
 
   /**
@@ -141,8 +250,9 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
    * recreate the entire `<oui-header-row>` when `displayedColumns` changes,
    * which would leave an observer on a detached element.
    *
-   * To prevent infinite loops (our own handle additions trigger subtree
-   * mutations), we disconnect before reinit and reconnect after.
+   * Only triggers a reinit when the set of header cell column IDs actually
+   * changes — body row additions/removals (infinite scroll, pagination) fire
+   * the same MutationObserver but must not cause a reinit loop.
    */
   private _watchHeaderRow(): void {
     const host = this._elementRef.nativeElement;
@@ -150,6 +260,25 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
       if (this._reinitScheduled) {
         return;
       }
+      // Snapshot current header cell column IDs and compare against what we
+      // have stored. If the set is unchanged (e.g. only body rows changed),
+      // skip the reinit entirely.
+      const currentHeaderIds = new Set(
+        Array.from(
+          host.querySelectorAll<HTMLElement>('oui-header-cell, th[oui-header-cell]')
+        )
+          .map((c) => this._getColumnId(c))
+          .filter(Boolean)
+      );
+      const storedIds = this._columnWidths;
+      const headerChanged =
+        currentHeaderIds.size !== storedIds.size ||
+        [...currentHeaderIds].some((id) => !storedIds.has(id));
+
+      if (!headerChanged) {
+        return; // Body rows or other subtree changes — not a header column change.
+      }
+
       this._reinitScheduled = true;
       this._mutationObserver?.disconnect();
       setTimeout(() => {
@@ -173,18 +302,241 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     // Detach old pointerdown listeners.
     this._handleUnlisteners.forEach((fn) => fn());
     this._handleUnlisteners = [];
+    // Reconcile any columns that were removed: clean up their stored widths
+    // and redistribute freed space to the last remaining column.
+    this._reconcileRemovedColumns();
     this._initHandles();
+    // Compute widths for any newly added columns (and adjust existing ones)
+    // BEFORE the final reapply pass so _reapplyStoredWidths sees the
+    // already-updated _columnWidths map and applies correct values to every
+    // cell — including body cells CDK may render after header cells.
+    this._snapshotNewColumns();
     this._reapplyStoredWidths();
+  }
+
+  /**
+   * Detects columns that have been removed from the DOM since the last reinit,
+   * deletes them from state, and redistributes the freed space to the last
+   * remaining column so the table continues to fill its container.
+   */
+  private _reconcileRemovedColumns(): void {
+    const host = this._elementRef.nativeElement;
+    const headerCells = Array.from(
+      host.querySelectorAll<HTMLElement>('oui-header-cell, th[oui-header-cell]')
+    );
+    const currentIds = new Set(
+      headerCells.map((c) => this._getColumnId(c)).filter(Boolean)
+    );
+
+    // If CDK is in the middle of rebuilding the header row, all cells are
+    // momentarily absent. Deleting all stored widths here would cause
+    // _snapshotNewColumns to re-initialise every column at effectiveMinWidth.
+    // Guard: skip reconciliation when no header cells are present but we have
+    // stored widths — that's a transient state, not a real removal.
+    if (currentIds.size === 0 && this._columnWidths.size > 0) {
+      return;
+    }
+
+    const removedIds: string[] = [];
+    this._columnWidths.forEach((_, columnId) => {
+      if (!currentIds.has(columnId)) {
+        removedIds.push(columnId);
+      }
+    });
+
+    if (removedIds.length === 0) {
+      return;
+    }
+
+    removedIds.forEach((id) => {
+      this._columnWidths.delete(id);
+      this._userResizedColumns.delete(id);
+      this._dragResizedColumns.delete(id);
+    });
+
+    // Redistribute the freed space to the last remaining column.
+    this._fillRemainingToLastColumn(headerCells);
+    // Do not emit — removal redistribution is auto-calculated, not user-driven.
+  }
+
+  /**
+   * Scans header cells that have no entry in `_columnWidths` (i.e. columns
+   * added after initial render) and pins widths for them.
+   *
+   * Strategy:
+   * - Existing columns that were never user-resized are shrunk to `minColumnWidth`,
+   *   freeing up space for the incoming column(s).
+   * - Existing columns that the user explicitly resized keep their width.
+   * - New columns share the remaining container space equally
+   *   (clamped to at least `minColumnWidth`).
+   */
+  private _snapshotNewColumns(): void {
+    const host = this._elementRef.nativeElement;
+    const headerCells = Array.from(
+      host.querySelectorAll<HTMLElement>('oui-header-cell, th[oui-header-cell]')
+    );
+
+    const newColumnIds: string[] = [];
+    headerCells.forEach((cell) => {
+      const columnId = this._getColumnId(cell);
+      if (!columnId || this._columnWidths.has(columnId)) {
+        return;
+      }
+      newColumnIds.push(columnId);
+    });
+
+    if (newColumnIds.length === 0) {
+      return;
+    }
+
+
+    // Find the last existing column in DOM order (rightmost column that already
+    // has a stored width, i.e. was present before this batch of additions).
+    let lastExistingColumnId = '';
+    for (let i = headerCells.length - 1; i >= 0; i--) {
+      const id = this._getColumnId(headerCells[i]);
+      if (id && this._columnWidths.has(id)) {
+        lastExistingColumnId = id;
+        break;
+      }
+    }
+
+    // Shrink only the last existing column to _effectiveMinWidth (if the user
+    // never explicitly resized it) so the new column(s) can claim the freed
+    // space. All other columns remain untouched.
+    if (
+      lastExistingColumnId &&
+      !this._userResizedColumns.has(lastExistingColumnId)
+    ) {
+      const cells = this._getColumnCells(lastExistingColumnId);
+      this._applyWidthToCells(this._effectiveMinWidth, cells);
+      this._columnWidths.set(lastExistingColumnId, this._effectiveMinWidth);
+    }
+
+    // New column(s) share the remaining container space equally,
+    // clamped to at least _effectiveMinWidth.
+    const containerWidth = host.parentElement
+      ? host.parentElement.clientWidth
+      : 0;
+    let occupiedWidth = 0;
+    this._columnWidths.forEach((w) => (occupiedWidth += w));
+    const remaining = Math.max(0, containerWidth - occupiedWidth);
+    const newColWidth = Math.max(
+      this._effectiveMinWidth,
+      Math.floor(remaining / newColumnIds.length)
+    );
+
+    // For each new column, prefer a consumer-supplied width from the
+    // `columnWidths` input when available and positive.
+    newColumnIds.forEach((columnId) => {
+      const inputWidth = this.columnWidths[columnId];
+      if (inputWidth != null && inputWidth > 0) {
+        this._columnWidths.set(columnId, inputWidth);
+        this._userResizedColumns.add(columnId);
+      } else {
+        this._columnWidths.set(columnId, newColWidth);
+      }
+    });
+
+    // Update the stylesheet immediately so CDK-created body cells receive
+    // the correct width via CSS as soon as they appear in the DOM.
+    this._updateStyleSheet();
+    this._syncTableWidth();
+    // Do not emit — new-column widths are auto-calculated, not user-driven.
   }
 
   /** Re-applies every previously-set column width to freshly-rendered cells. */
   private _reapplyStoredWidths(): void {
+    this._doApply();
+    if (this._pendingApplyRaf !== null) {
+      cancelAnimationFrame(this._pendingApplyRaf);
+    }
+    this._pendingApplyRaf = requestAnimationFrame(() => {
+      this._doApplyInline();
+      this._pendingApplyRaf = requestAnimationFrame(() => {
+        this._pendingApplyRaf = null;
+        this._doApplyInline();
+      });
+    });
+  }
+
+  /**
+   * Full apply: updates the stylesheet (primary mechanism for flicker prevention)
+   * and also stamps inline styles for cells already in the DOM.
+   * Called once synchronously at reinit time.
+   */
+  private _doApply(): void {
+    this._updateStyleSheet();
+    this._doApplyInline();
+  }
+
+  /**
+   * Inline-only apply: stamps width styles on cells currently in the DOM.
+   * Used in the rAF retry passes where the stylesheet is already up-to-date
+   * (updated synchronously in _doApply) — avoids redundant stylesheet rewrites.
+   */
+  private _doApplyInline(): void {
     this._columnWidths.forEach((width, columnId) => {
       const cells = this._getColumnCells(columnId);
       this._applyWidthToCells(width, cells);
     });
-    // Restore the table's explicit width so it matches the stored column widths.
-    this._syncNativeTableWidth();
+    this._syncTableWidth();
+  }
+
+  /**
+   * Creates a <style> element in the document <head> scoped to this table via
+   * a unique `data-oui-resize-id` attribute. CSS rules applied here take effect
+   * on any cell CDK creates with a matching `cdk-column-*` class — including
+   * cells rendered after our synchronous code runs — eliminating render flicker.
+   */
+  private _initStyleSheet(): void {
+    if (this._styleEl) {
+      return;
+    }
+    this._styleEl = document.createElement('style');
+    this._styleEl.setAttribute('data-oui-resize-id', this._tableId);
+    document.head.appendChild(this._styleEl);
+  }
+
+  /** Regenerates the scoped stylesheet from the current `_columnWidths` map. */
+  private _updateStyleSheet(): void {
+    if (!this._styleEl) {
+      return;
+    }
+    const isNativeTable = this._elementRef.nativeElement.tagName === 'TABLE';
+    const scope = `[data-oui-resize-id="${this._tableId}"]`;
+    const rules: string[] = [];
+    this._columnWidths.forEach((width, columnId) => {
+      const px = `${width}px`;
+      const sel = `${scope} .cdk-column-${columnId}`;
+      const flex = isNativeTable ? '' : ` flex: 0 0 ${px} !important;`;
+      rules.push(
+        `${sel} { width: ${px} !important; min-width: ${px} !important;` +
+          ` max-width: ${px} !important; box-sizing: border-box !important;${flex} }`
+      );
+    });
+    this._styleEl.textContent = rules.join('\n');
+  }
+
+  /** Emits only explicitly drag-resized column widths to `columnWidthsChange`.
+   * Auto-calculated widths (init, last-column fill, add/remove redistribution)
+   * are intentionally excluded so the parent's persisted map is never
+   * overwritten by transient layout computations.
+   */
+  private _emitColumnWidths(): void {
+    if (this._dragResizedColumns.size === 0) {
+      return;
+    }
+    const out: Record<string, number> = {};
+    this._dragResizedColumns.forEach((id) => {
+      const w = this._columnWidths.get(id);
+      if (w !== undefined) {
+        out[id] = w;
+      }
+    });
+    this._ngZone.run(() => {
+      this.columnWidthsChange.emit(out);
+    });
   }
 
   private _initHandles(): void {
@@ -264,11 +616,91 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
       Number.parseFloat(style.paddingLeft) +
       Number.parseFloat(style.paddingRight);
 
-    // Clamp to at least minColumnWidth input (if provided) so both constraints apply.
-    // The padding already includes the 40px reserved for the menu button.
-    this._minCellWidth = Math.max(this.minColumnWidth, contentWidth + padding);
+    // Minimum drag floor:
+    //   - Must be at least contentWidth + padding (content must fit).
+    //   - If the column was initialised BELOW _effectiveMinWidth (e.g. equal-
+    //     division gave 133px with a 200px minimum), we honour the smaller
+    //     initial width so the first drag move doesn't immediately snap the
+    //     column up to 200. In all other cases the floor is _effectiveMinWidth.
+    this._minCellWidth = Math.max(
+      contentWidth + padding,
+      Math.min(this._startWidth, this._effectiveMinWidth)
+    );
     this._columnId = this._getColumnId(headerCell);
     this._columnCells = this._getColumnCells(this._columnId);
+
+    // Find the elastic column: the rightmost column that is NOT the dragged
+    // one. If the dragged column IS the rightmost, disable elastic entirely
+    // (dragging the last column's handle should grow/shrink the table freely).
+    this._elasticColumnId = '';
+    this._elasticColumnStartWidth = 0;
+    this._elasticColumnWasUserResized = false;
+    this._elasticEnabled = false;
+    const allHeaderCells = Array.from(
+      this._elementRef.nativeElement.querySelectorAll<HTMLElement>(
+        'oui-header-cell, th[oui-header-cell]'
+      )
+    );
+    // Find the actual last column (rightmost) in DOM order.
+    let lastColumnId = '';
+    for (let i = allHeaderCells.length - 1; i >= 0; i--) {
+      const id = this._getColumnId(allHeaderCells[i]);
+      if (id && this._columnWidths.has(id)) {
+        lastColumnId = id;
+        break;
+      }
+    }
+    // Only enable elastic when dragging a non-last column and the table
+    // currently fits the container (no horizontal scroll present).
+    if (lastColumnId && lastColumnId !== this._columnId) {
+      this._elasticColumnId = lastColumnId;
+      this._elasticColumnStartWidth = this._columnWidths.get(lastColumnId) ?? 0;
+      this._elasticColumnWasUserResized = this._userResizedColumns.has(lastColumnId);
+      let startTotal = 0;
+      this._columnWidths.forEach((w) => (startTotal += w));
+      const cw = this._elementRef.nativeElement.parentElement
+        ? this._elementRef.nativeElement.parentElement.clientWidth
+        : 0;
+      // Allow 1 px of rounding slack.
+      this._elasticEnabled = cw > 0 && startTotal <= cw + 1;
+
+      // Compute the elastic column's true minimum: measure its header cell's
+      // content + padding the same way we do for the dragged column.
+      // When the elastic column started ABOVE effectiveMinWidth we use
+      // effectiveMinWidth as the floor (normal case).
+      // When it started BELOW (e.g. equal-division gave 133px with 200px
+      // default minimum) we fall back to content+padding so the elastic column
+      // can still absorb the drag instead of pinning immediately.
+      const elasticHeaderCell = allHeaderCells.find(
+        (c) => this._getColumnId(c) === lastColumnId
+      );
+      let elasticContentWidth = 0;
+      if (elasticHeaderCell) {
+        Array.from(elasticHeaderCell.childNodes).forEach((node) => {
+          if (
+            node instanceof HTMLElement &&
+            !node.classList.contains('oui-col-resize-handle')
+          ) {
+            elasticContentWidth += node.scrollWidth;
+          } else if (node.nodeType === Node.TEXT_NODE) {
+            const range = document.createRange();
+            range.selectNodeContents(node);
+            elasticContentWidth += range.getBoundingClientRect().width;
+          }
+        });
+        const ecs = globalThis.getComputedStyle(elasticHeaderCell);
+        const elasticPadding =
+          Number.parseFloat(ecs.paddingLeft) +
+          Number.parseFloat(ecs.paddingRight);
+        const contentFloor = Math.max(1, elasticContentWidth + elasticPadding);
+        this._elasticColumnMinWidth =
+          this._elasticColumnStartWidth >= this._effectiveMinWidth
+            ? this._effectiveMinWidth   // started above min → honour min
+            : contentFloor;             // started below min → shrink to content
+      } else {
+        this._elasticColumnMinWidth = this._effectiveMinWidth;
+      }
+    }
 
     handle.setPointerCapture(e.pointerId);
 
@@ -314,12 +746,79 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     }
     const newWidth = Math.max(this._minCellWidth, this._startWidth + delta);
 
-    // For native <table> elements, grow (or shrink) the table's explicit width
-    // to match the new sum of all column widths. Without this the browser
-    // re-distributes all columns within the fixed container width, making it
-    // impossible to resize beyond the container boundary.
-    this._syncNativeTableWidth(this._columnId, newWidth);
+    // Elastic column logic: keep the table at exactly containerWidth by
+    // adjusting the rightmost non-dragged column in both directions.
+    //   • Shrink dragged column → elastic column grows to fill freed space.
+    //   • Expand dragged column → elastic column compresses to absorb overflow.
+    // A scrollbar only appears when the elastic column hits _effectiveMinWidth.
+    // Re-evaluate whether elastic should be active on every move: if the table
+    // was scrolling at drag-start but the user has since shrunk columns enough
+    // that the total now fits, we engage elastic from that point forward.
+    if (this._elasticColumnId) {
+      const containerWidth = this._elementRef.nativeElement.parentElement
+        ? this._elementRef.nativeElement.parentElement.clientWidth
+        : 0;
 
+      // Compute what the total would be with the new drag width but without
+      // any elastic adjustment, to decide whether elastic should activate.
+      if (containerWidth > 0) {
+        let currentTotal = newWidth;
+        this._columnWidths.forEach((w, id) => {
+          if (id !== this._columnId) currentTotal += w;
+        });
+        // Engage elastic when the projected total fits (or the table already fits).
+        if (!this._elasticEnabled && currentTotal <= containerWidth + 1) {
+          this._elasticEnabled = true;
+          // Refresh elastic start width to the current stored value so the
+          // transition into elastic mode is seamless.
+          this._elasticColumnStartWidth =
+            this._columnWidths.get(this._elasticColumnId) ?? this._elasticColumnStartWidth;
+          this._elasticColumnWasUserResized =
+            this._userResizedColumns.has(this._elasticColumnId);
+        }
+      }
+    }
+
+    if (this._elasticEnabled && this._elasticColumnId) {
+      const containerWidth = this._elementRef.nativeElement.parentElement
+        ? this._elementRef.nativeElement.parentElement.clientWidth
+        : 0;
+
+      if (containerWidth > 0) {
+        // Sum of every column except the dragged one and the elastic one.
+        let fixedTotal = 0;
+        this._columnWidths.forEach((w, id) => {
+          if (id !== this._columnId && id !== this._elasticColumnId) {
+            fixedTotal += w;
+          }
+        });
+        // The elastic column gets whatever space is left after the dragged
+        // column and all fixed columns are accounted for.
+        const targetElasticWidth = containerWidth - fixedTotal - newWidth;
+        if (targetElasticWidth >= this._elasticColumnMinWidth) {
+          // Elastic column fills the gap; it is not considered user-resized.
+          this._columnWidths.set(this._elasticColumnId, targetElasticWidth);
+          this._userResizedColumns.delete(this._elasticColumnId);
+        } else {
+          // Hit minimum — pin it and let the table overflow (scrollbar appears).
+          this._columnWidths.set(this._elasticColumnId, this._elasticColumnMinWidth);
+          this._userResizedColumns.add(this._elasticColumnId);
+        }
+        const elasticWidth = this._columnWidths.get(this._elasticColumnId) ?? 0;
+        this._applyWidthToCells(
+          elasticWidth,
+          this._getColumnCells(this._elasticColumnId)
+        );
+      }
+    }
+
+    // Update the stylesheet for this column so the !important CSS rule
+    // reflects the live drag width — inline styles alone lose to !important.
+    // We write directly to _columnWidths here only as a temporary preview;
+    // _onPointerUp will set the final committed value.
+    this._columnWidths.set(this._columnId, newWidth);
+    this._updateStyleSheet();
+    this._syncTableWidth();
     this._applyWidth(newWidth);
   }
 
@@ -375,10 +874,17 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
 
     // Persist so we can restore the width if columns are reordered later.
     this._columnWidths.set(this._columnId, finalWidth);
-    // Keep the table's explicit width in sync with the final column widths.
-    this._syncNativeTableWidth();
+    // Mark as explicitly user-resized so future dynamic column additions
+    // do not shrink this column back to _effectiveMinWidth.
+    this._userResizedColumns.add(this._columnId);
+    // Track as drag-resized so this column is included in the next emit.
+    this._dragResizedColumns.add(this._columnId);
+    // Keep the table's explicit width and the stylesheet in sync.
+    this._updateStyleSheet();
+    this._syncTableWidth();
+    this._emitColumnWidths();
 
-    // Emit inside zone so Angular can run change detection if needed.
+    // Emit the single-column event inside zone so Angular can run CD.
     this._ngZone.run(() => {
       this.columnResized.emit({ columnId: this._columnId, width: finalWidth });
     });
@@ -390,6 +896,29 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     }
     this._isDragging = false;
     this._cleanupDragListeners();
+
+    // Roll back the temporary drag-preview width written to _columnWidths
+    // during pointermove. Without this, cancelling a drag leaves the in-progress
+    // width permanently stored and corrupts future column add/remove calculations.
+    this._columnWidths.set(this._columnId, this._startWidth);
+    // Restore the elastic column to its exact pre-drag state.
+    if (this._elasticColumnId) {
+      this._columnWidths.set(this._elasticColumnId, this._elasticColumnStartWidth);
+      if (this._elasticColumnWasUserResized) {
+        this._userResizedColumns.add(this._elasticColumnId);
+      } else {
+        this._userResizedColumns.delete(this._elasticColumnId);
+      }
+      this._applyWidthToCells(
+        this._elasticColumnStartWidth,
+        this._getColumnCells(this._elasticColumnId)
+      );
+    }
+    this._updateStyleSheet();
+    this._syncTableWidth();
+    // Restore the cells to the pre-drag width.
+    this._applyWidthToCells(this._startWidth, this._columnCells);
+
     this._renderer.removeClass(
       this._elementRef.nativeElement,
       'oui-table-resizing'
@@ -417,48 +946,23 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
   }
 
   /**
-   * For native `<table>` elements, sets the table's inline `width` to the
-   * sum of all column widths so the table can overflow its container and
-   * the scroll container shows a horizontal scrollbar.
+   * Sets the table host's inline `width` to the sum of all column widths.
+   * Applies to both native `<table>` and CDK flex tables (`oui-table`).
    *
-   * Pass `overrideColumnId` + `overrideWidth` to preview a width that
-   * hasn't been committed to `_columnWidths` yet (e.g. during a live drag).
-   * Without arguments the stored widths are summed as-is.
-   *
-   * Has no effect on non-native (CDK/flex) tables.
+   * When the sum exceeds the container width the scroll container shows a
+   * horizontal scrollbar. When the sum is less than the container the table
+   * is narrower and the container background is visible to the right —
+   * matching the same behaviour as when the scrollbar is visible.
    */
-  private _syncNativeTableWidth(
-    overrideColumnId?: string,
-    overrideWidth?: number
-  ): void {
-    const host = this._elementRef.nativeElement;
-    if (host.tagName !== 'TABLE') {
-      return;
-    }
+  private _syncTableWidth(): void {
     let total = 0;
-    this._columnWidths.forEach((w, id) => {
-      total +=
-        id === overrideColumnId && overrideWidth !== undefined
-          ? overrideWidth
-          : w;
-    });
-    // If overrideColumnId is being dragged but not yet in the map (edge case
-    // during very first move), add overrideWidth once.
-    if (
-      overrideColumnId !== undefined &&
-      overrideWidth !== undefined &&
-      !this._columnWidths.has(overrideColumnId)
-    ) {
-      total += overrideWidth;
-    }
+    this._columnWidths.forEach((w) => (total += w));
     if (total > 0) {
-      // Set the table to exactly the sum of column widths — no Math.max with
-      // containerWidth. If the table were wider than the column sum,
-      // table-layout:fixed would proportionally distribute the surplus to all
-      // columns, shifting columns the user did not touch. The scroll container
-      // (overflow-x: auto) handles horizontal overflow when columns grow past
-      // the container, and shows a gap at the right when they shrink below it.
-      this._renderer.setStyle(host, 'width', `${total}px`);
+      this._renderer.setStyle(
+        this._elementRef.nativeElement,
+        'width',
+        `${total}px`
+      );
     }
   }
 
@@ -494,6 +998,14 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     this._mutationObserver?.disconnect();
     this._overflowObserver?.disconnect();
     this._overflowObserver = null;
+    if (this._pendingApplyRaf !== null) {
+      cancelAnimationFrame(this._pendingApplyRaf);
+      this._pendingApplyRaf = null;
+    }
+    if (this._styleEl) {
+      this._styleEl.remove();
+      this._styleEl = null;
+    }
     this._renderer.removeClass(
       this._elementRef.nativeElement,
       'oui-table-resizing'

--- a/ui/src/components/table/column-resize/oui-column-resize.directive.ts
+++ b/ui/src/components/table/column-resize/oui-column-resize.directive.ts
@@ -125,6 +125,14 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     // snapshotted column widths so further resizes that grow beyond the
     // container can set the table wider than the container.
     this._syncNativeTableWidth();
+    // Remove min-width now that we have an explicit pixel width on the table.
+    // Keeping min-width: 100% would override the explicit width whenever the
+    // column sum drops below the container width, causing table-layout:fixed
+    // to redistribute the surplus pixels across ALL columns — exactly the
+    // bidirectional-shift bug. The scroll container handles overflow instead.
+    if (isNativeTable) {
+      this._renderer.removeStyle(host, 'min-width');
+    }
   }
 
   /**
@@ -444,12 +452,13 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
       total += overrideWidth;
     }
     if (total > 0) {
-      // Use max so the table stays at least as wide as its container.
-      const containerWidth = host.parentElement
-        ? host.parentElement.clientWidth
-        : 0;
-      const tableWidth = Math.max(total, containerWidth);
-      this._renderer.setStyle(host, 'width', `${tableWidth}px`);
+      // Set the table to exactly the sum of column widths — no Math.max with
+      // containerWidth. If the table were wider than the column sum,
+      // table-layout:fixed would proportionally distribute the surplus to all
+      // columns, shifting columns the user did not touch. The scroll container
+      // (overflow-x: auto) handles horizontal overflow when columns grow past
+      // the container, and shows a gap at the right when they shrink below it.
+      this._renderer.setStyle(host, 'width', `${total}px`);
     }
   }
 

--- a/ui/src/components/table/column-resize/oui-column-resize.directive.ts
+++ b/ui/src/components/table/column-resize/oui-column-resize.directive.ts
@@ -265,7 +265,9 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
       // skip the reinit entirely.
       const currentHeaderIds = new Set(
         Array.from(
-          host.querySelectorAll<HTMLElement>('oui-header-cell, th[oui-header-cell]')
+          host.querySelectorAll<HTMLElement>(
+            'oui-header-cell, th[oui-header-cell]'
+          )
         )
           .map((c) => this._getColumnId(c))
           .filter(Boolean)
@@ -388,7 +390,6 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     if (newColumnIds.length === 0) {
       return;
     }
-
 
     // Find the last existing column in DOM order (rightmost column that already
     // has a stored width, i.e. was present before this batch of additions).
@@ -655,7 +656,8 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     if (lastColumnId && lastColumnId !== this._columnId) {
       this._elasticColumnId = lastColumnId;
       this._elasticColumnStartWidth = this._columnWidths.get(lastColumnId) ?? 0;
-      this._elasticColumnWasUserResized = this._userResizedColumns.has(lastColumnId);
+      this._elasticColumnWasUserResized =
+        this._userResizedColumns.has(lastColumnId);
       let startTotal = 0;
       this._columnWidths.forEach((w) => (startTotal += w));
       const cw = this._elementRef.nativeElement.parentElement
@@ -695,8 +697,8 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
         const contentFloor = Math.max(1, elasticContentWidth + elasticPadding);
         this._elasticColumnMinWidth =
           this._elasticColumnStartWidth >= this._effectiveMinWidth
-            ? this._effectiveMinWidth   // started above min → honour min
-            : contentFloor;             // started below min → shrink to content
+            ? this._effectiveMinWidth // started above min → honour min
+            : contentFloor; // started below min → shrink to content
       } else {
         this._elasticColumnMinWidth = this._effectiveMinWidth;
       }
@@ -772,9 +774,11 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
           // Refresh elastic start width to the current stored value so the
           // transition into elastic mode is seamless.
           this._elasticColumnStartWidth =
-            this._columnWidths.get(this._elasticColumnId) ?? this._elasticColumnStartWidth;
-          this._elasticColumnWasUserResized =
-            this._userResizedColumns.has(this._elasticColumnId);
+            this._columnWidths.get(this._elasticColumnId) ??
+            this._elasticColumnStartWidth;
+          this._elasticColumnWasUserResized = this._userResizedColumns.has(
+            this._elasticColumnId
+          );
         }
       }
     }
@@ -801,7 +805,10 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
           this._userResizedColumns.delete(this._elasticColumnId);
         } else {
           // Hit minimum — pin it and let the table overflow (scrollbar appears).
-          this._columnWidths.set(this._elasticColumnId, this._elasticColumnMinWidth);
+          this._columnWidths.set(
+            this._elasticColumnId,
+            this._elasticColumnMinWidth
+          );
           this._userResizedColumns.add(this._elasticColumnId);
         }
         const elasticWidth = this._columnWidths.get(this._elasticColumnId) ?? 0;
@@ -903,7 +910,10 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     this._columnWidths.set(this._columnId, this._startWidth);
     // Restore the elastic column to its exact pre-drag state.
     if (this._elasticColumnId) {
-      this._columnWidths.set(this._elasticColumnId, this._elasticColumnStartWidth);
+      this._columnWidths.set(
+        this._elasticColumnId,
+        this._elasticColumnStartWidth
+      );
       if (this._elasticColumnWasUserResized) {
         this._userResizedColumns.add(this._elasticColumnId);
       } else {

--- a/ui/src/components/table/table-columns.module.ts
+++ b/ui/src/components/table/table-columns.module.ts
@@ -8,6 +8,7 @@ import { OuiColumnMenuDirective } from './column-menu/oui-column-menu.directive'
 import { OuiColumnMenuPanelComponent } from './column-menu/oui-column-menu-panel.component';
 import { OuiResizableColumnsDirective } from './column-resize/oui-column-resize.directive';
 import { OuiReorderableColumnsDirective } from './column-reorder/oui-column-reorder.directive';
+import { OuiTooltipModule } from '../tooltip/tooltip-module';
 
 const COLUMN_FEATURE_DECLARATIONS = [
   OuiColumnMenuDirective,
@@ -32,6 +33,7 @@ const COLUMN_FEATURE_DECLARATIONS = [
     OuiSortModule,
     OuiIconModule,
     OuiMenuModule,
+    OuiTooltipModule,
   ],
   declarations: COLUMN_FEATURE_DECLARATIONS,
   exports: [


### PR DESCRIPTION
Enhance column resizing functionality with improved width management and elastic column behavior
This pull request introduces improvements to the interactive table's column resizing and reordering experience, updates UI elements for clarity, and fixes related visual and accessibility issues. The changes include a significant refactor of the column reordering logic for more precise and intuitive drag-and-drop, as well as UI/UX tweaks to the column menu and sort indicators. The package version is also bumped to `11.0.5`.

**Table Column Reordering Improvements:**

* Refactored the column reordering logic in `OuiReorderableColumnsDirective` to use an "insertion slot" model, allowing more precise placement of columns when dragging. The drop indicator and ghost visuals are now constrained to the visible area (viewport and scroll container), and drag-and-drop is more robust and accessible. Prevents accidental sort triggers after dragging and ensures columns can't be dropped in invalid positions. [[1]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeR62-R66) [[2]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeL259-R291) [[3]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeR335-R392) [[4]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeR438-R488) [[5]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeL402-R533) [[6]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeR542-R557) [[7]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeL457-R622) [[8]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeL505-L539)
* Removed the old center-based target index logic and replaced it with edge-based slot calculation for more intuitive drop behavior.
* Improved drag visuals: the ghost element now matches the visible table height, and the drop indicator is accurately positioned and only shown for valid drops. [[1]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeL259-R291) [[2]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeR542-R557) [[3]](diffhunk://#diff-96e6eec51edf6a5cc80202e8376ac0cd91f3dc261e3d329f0997528d73f05ddeL457-R622)

**Table Column Menu and Sort Indicator UI/UX:**

* Updated the sort indicator in the column menu to use a custom SVG arrow and improved its visual feedback for ascending/descending states. Tooltip and ARIA labels have been corrected for accessibility and clarity. [[1]](diffhunk://#diff-75ab3768e4f890d915ce62acbc1ab0f3302b844df46dec27e13fc907a91d08eeR9-R30) [[2]](diffhunk://#diff-bdf5313ea6e47d9949549d1d1e49ba0b44cc2087f66383e3fbfe9c8db7cb26e6R54-R55) [[3]](diffhunk://#diff-bdf5313ea6e47d9949549d1d1e49ba0b44cc2087f66383e3fbfe9c8db7cb26e6R79-R89)
* Simplified column move menu item text from "Move column to left/right" to "Move to left/right" for brevity.

**Version and Changelog Updates:**

* Bumped package versions from `11.0.4` to `11.0.5` in `package.json`, `ui/package.json`, and `ui/package-lock.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaL3-R3) [[3]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L3-R9)
* Added a changelog entry for version `11.0.5` summarizing the interactive table resize improvements.