### PR TITLE
fix: upgrade deprecated GitHub Actions in deploy-storybook workflow

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -34,11 +34,11 @@ jobs:
       - run: npm ci
       - run: npm run build-storybook
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './storybook-static'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
The deploy-storybook workflow was failing with:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.

`actions/upload-pages-artifact@v2` internally depended on the deprecated `upload-artifact@v3`.

**Changes:**
| Action | Old | New |
|--------|-----|-----|
| `configure-pages` | `@v3` | `@v6` |
| `upload-pages-artifact` | `@v2` | `@v3` |
| `deploy-pages` | `@v2` | `@v5` |