### PR TITLE
Add a class in oui-panel to overcome the issue of panel position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oncehub-ui",
-  "version": "11.2.0",
+  "version": "11.2.1-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oncehub-ui",
-      "version": "11.2.0",
+      "version": "11.2.1-beta.0",
       "dependencies": {
         "@angular-devkit/architect": "0.2102.15",
         "@angular-devkit/core": "21.2.15",
@@ -1611,40 +1611,6 @@
         "chokidar": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@angular/build/node_modules/@angular-devkit/architect/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@angular/build/node_modules/@angular-devkit/architect/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular/build/node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oncehub-ui",
-  "version": "11.2.0",
+  "version": "11.2.1-beta.0",
   "scripts": {
     "ng": "ng",
     "build": "ng build ui",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.2.0",
+  "version": "11.2.1-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/ui",
-      "version": "11.2.0",
+      "version": "11.2.1-beta.0",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncehub/ui",
-  "version": "11.2.0",
+  "version": "11.2.1-beta.0",
   "description": "Oncehub UI",
   "peerDependencies": {},
   "repository": {

--- a/ui/src/components/panel/panel.spec.ts
+++ b/ui/src/components/panel/panel.spec.ts
@@ -203,4 +203,73 @@ describe('OuiPanel', () => {
     const role = overlayPanel ? overlayPanel.getAttribute('role') : '';
     expect(role).toBe('dialog', 'Expected panel to have the "dialog" role.');
   });
+
+  it('should mirror non-position host classes onto the overlay and remove them when toggled', fakeAsync(() => {
+    const fixture = createComponent(SimplePanel, [], [FakeIcon]);
+    fixture.detectChanges();
+
+    const hostEl: HTMLElement =
+      fixture.nativeElement.querySelector('oui-panel');
+    expect(hostEl).toBeTruthy();
+
+    // Add a custom class on the host and force the panel to copy classes
+    hostEl.classList.add('my-custom-host-class');
+    // MutationObserver may not run in the test environment, call the copy method directly.
+    (fixture.componentInstance.panel as any)._copyHostClasses?.();
+    fixture.detectChanges();
+
+    fixture.componentInstance.trigger.openPanel();
+    fixture.detectChanges();
+    tick(0);
+    fixture.detectChanges();
+
+    let overlayPanel = overlayContainerElement.querySelector(
+      '.oui-panel'
+    ) as HTMLElement;
+    expect(overlayPanel).toBeTruthy();
+    expect(overlayPanel.classList.contains('my-custom-host-class')).toBeTrue();
+
+    // Remove the host class and ensure overlay no longer has it
+    hostEl.classList.remove('my-custom-host-class');
+    (fixture.componentInstance.panel as any)._copyHostClasses?.();
+    fixture.detectChanges();
+
+    overlayPanel = overlayContainerElement.querySelector(
+      '.oui-panel'
+    ) as HTMLElement;
+    expect(overlayPanel.classList.contains('my-custom-host-class')).toBeFalse();
+  }));
+
+  it('should not mirror position-related classes from the host; position classes come from setPositionClasses()', fakeAsync(() => {
+    const fixture = createComponent(SimplePanel, [], [FakeIcon]);
+    fixture.detectChanges();
+
+    const hostEl: HTMLElement =
+      fixture.nativeElement.querySelector('oui-panel');
+    expect(hostEl).toBeTruthy();
+
+    // Intentionally add a position-like class on the host (should be ignored).
+    hostEl.classList.add('oui-panel-before');
+    // Force the component to use a different position via input setter and apply position classes.
+    fixture.componentInstance.panel.xPosition = 'after';
+    fixture.componentInstance.panel.yPosition = 'below';
+    (fixture.componentInstance.panel as any).setPositionClasses?.(
+      'after',
+      'below'
+    );
+    fixture.detectChanges();
+
+    fixture.componentInstance.trigger.openPanel();
+    fixture.detectChanges();
+    tick(0);
+    fixture.detectChanges();
+
+    const overlayPanel = overlayContainerElement.querySelector(
+      '.oui-panel'
+    ) as HTMLElement;
+    expect(overlayPanel).toBeTruthy();
+    // The overlay should reflect the programmatic position classes, not the host-supplied one.
+    expect(overlayPanel.classList.contains('oui-panel-after')).toBeTrue();
+    expect(overlayPanel.classList.contains('oui-panel-before')).toBeFalse();
+  }));
 });

--- a/ui/src/components/panel/panel.ts
+++ b/ui/src/components/panel/panel.ts
@@ -16,6 +16,7 @@ import {
   OnDestroy,
   inject,
   HostAttributeToken,
+  ChangeDetectorRef,
 } from '@angular/core';
 import { PanelPositionX, PanelPositionY } from './panel-positions';
 import {
@@ -63,7 +64,7 @@ export function OUI_PANEL_DEFAULT_OPTIONS_FACTORY(): OuiPanelDefaultOptions {
   exportAs: 'ouiPanel',
   standalone: false,
 })
-export class OuiPanel implements OnInit, OuiPanelOverlay {
+export class OuiPanel implements OnInit, OnDestroy, OuiPanelOverlay {
   private _defaultOptions = inject<OuiPanelDefaultOptions>(
     OUI_PANEL_DEFAULT_OPTIONS
   );
@@ -77,6 +78,10 @@ export class OuiPanel implements OnInit, OuiPanelOverlay {
   public escapeEvent: Subject<void> = new Subject<void>();
 
   readonly width = input<number>();
+
+  private _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private _changeDetectorRef = inject(ChangeDetectorRef);
+  private _classObserver: MutationObserver | null = null;
 
   /** Config object to be passed into the menu's ngClass */
   _classList: { [key: string]: boolean } = {};
@@ -129,6 +134,69 @@ export class OuiPanel implements OnInit, OuiPanelOverlay {
 
   ngOnInit() {
     this.setPositionClasses();
+    this._copyHostClasses();
+    // Watch for dynamic class changes on the host element and mirror them
+    // onto the panel's `_classList` so the overlay reflects host classes.
+    try {
+      this._classObserver = new MutationObserver((mutations) => {
+        for (const m of mutations) {
+          if (m.type === 'attributes' && m.attributeName === 'class') {
+            this._copyHostClasses();
+          }
+        }
+      });
+      this._classObserver.observe(this._elementRef.nativeElement, {
+        attributes: true,
+        attributeFilter: ['class'],
+      });
+    } catch (e) {
+      // MutationObserver may not be available in some environments; ignore.
+    }
+  }
+
+  ngOnDestroy() {
+    if (this._classObserver) {
+      this._classObserver.disconnect();
+      this._classObserver = null;
+    }
+  }
+
+  /** Copies classes from the host `oui-panel` element onto `_classList`. */
+  private _copyHostClasses() {
+    try {
+      const el = this._elementRef.nativeElement;
+      if (!el) return;
+
+      const hostClasses = Array.from(el.classList || []).filter(
+        (c) =>
+          c !== 'oui-panel' && !/^oui-panel-(before|after|above|below)$/.test(c)
+      );
+      const hostSet = new Set(hostClasses);
+
+      // Remove any previously set classes that are not position classes and
+      // are no longer present on the host element.
+      for (const key of Object.keys(this._classList)) {
+        if (/^oui-panel-(before|after|above|below)$/.test(key)) {
+          continue;
+        }
+        if (!hostSet.has(key)) {
+          delete this._classList[key];
+        }
+      }
+
+      // Add host classes to the class list so the overlay mirrors them.
+      for (const c of hostClasses) {
+        this._classList[c] = true;
+      }
+      // Ensure OnPush templates are checked after we mutate the class map.
+      try {
+        this._changeDetectorRef.markForCheck();
+      } catch (e) {
+        // ignore in environments without change detector
+      }
+    } catch (e) {
+      // Defensive: ignore errors reading host classes
+    }
   }
 
   /**
@@ -148,6 +216,12 @@ export class OuiPanel implements OnInit, OuiPanelOverlay {
     classes['oui-panel-after'] = posX === 'after';
     classes['oui-panel-above'] = posY === 'above';
     classes['oui-panel-below'] = posY === 'below';
+    // Ensure OnPush templates are checked when position classes change.
+    try {
+      this._changeDetectorRef.markForCheck();
+    } catch (e) {
+      // ignore
+    }
   }
 
   public _handleMouseLeave(event: MouseEvent) {

--- a/ui/src/components/table/column-resize/oui-column-resize.directive.ts
+++ b/ui/src/components/table/column-resize/oui-column-resize.directive.ts
@@ -444,11 +444,11 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
   private _reapplyStoredWidths(): void {
     this._doApply();
     if (this._pendingApplyRaf !== null) {
-      cancelAnimationFrame(this._pendingApplyRaf);
+      globalThis.cancelAnimationFrame(this._pendingApplyRaf);
     }
-    this._pendingApplyRaf = requestAnimationFrame(() => {
+    this._pendingApplyRaf = globalThis.requestAnimationFrame(() => {
       this._doApplyInline();
-      this._pendingApplyRaf = requestAnimationFrame(() => {
+      this._pendingApplyRaf = globalThis.requestAnimationFrame(() => {
         this._pendingApplyRaf = null;
         this._doApplyInline();
       });
@@ -1021,7 +1021,7 @@ export class OuiResizableColumnsDirective implements AfterViewInit, OnDestroy {
     this._overflowObserver?.disconnect();
     this._overflowObserver = null;
     if (this._pendingApplyRaf !== null) {
-      cancelAnimationFrame(this._pendingApplyRaf);
+      globalThis.cancelAnimationFrame(this._pendingApplyRaf);
       this._pendingApplyRaf = null;
     }
     if (this._styleEl) {


### PR DESCRIPTION
This pull request introduces a new beta version (`11.2.1-beta.0`) for the `oncehub-ui` and `@oncehub/ui` packages and adds a significant enhancement to the `OuiPanel` component. The main feature is improved support for dynamically mirroring CSS classes from the host element to the overlay panel, ensuring that any class changes on the host are reflected in the overlay in real-time.

**Versioning updates:**

* Bumped the version of `oncehub-ui` and `@oncehub/ui` packages to `11.2.1-beta.0` in `package.json`, `ui/package.json`, and `ui/package-lock.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaL3-R3) [[3]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L3-R9)

**OuiPanel dynamic class mirroring:**

* Enhanced the `OuiPanel` component to implement `OnDestroy` and added logic to mirror all non-position-related CSS classes from the host element to the overlay panel. This includes:
  - Injecting `ElementRef` and setting up a `MutationObserver` to watch for class attribute changes on the host element.
  - Automatically copying any new or removed classes to the overlay panel's `_classList` property.
  - Cleaning up the observer on component destruction to avoid memory leaks. [[1]](diffhunk://#diff-fe6313afb28e95442ec1a7876df57ad8bf36db5b2730bc51756f85f3a164f384L66-R66) [[2]](diffhunk://#diff-fe6313afb28e95442ec1a7876df57ad8bf36db5b2730bc51756f85f3a164f384R81-R83) [[3]](diffhunk://#diff-fe6313afb28e95442ec1a7876df57ad8bf36db5b2730bc51756f85f3a164f384R135-R190)